### PR TITLE
NavigationController 생성

### DIFF
--- a/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
+++ b/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B21C1A8C2A513FBB007D98E9 /* RIBs+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21C1A8B2A513FBB007D98E9 /* RIBs+.swift */; };
 		B24F1D312A431E1700AA03DC /* ConvenienceStoreCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24F1D302A431E1700AA03DC /* ConvenienceStoreCell.swift */; };
 		B24F1D362A43E5B500AA03DC /* ProductListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24F1D352A43E5B500AA03DC /* ProductListViewController.swift */; };
 		B24F1D382A44171800AA03DC /* ProductHomePageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24F1D372A44171800AA03DC /* ProductHomePageViewController.swift */; };
@@ -92,6 +93,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		B21C1A8B2A513FBB007D98E9 /* RIBs+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RIBs+.swift"; sourceTree = "<group>"; };
 		B24F1D302A431E1700AA03DC /* ConvenienceStoreCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConvenienceStoreCell.swift; sourceTree = "<group>"; };
 		B24F1D352A43E5B500AA03DC /* ProductListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListViewController.swift; sourceTree = "<group>"; };
 		B24F1D372A44171800AA03DC /* ProductHomePageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductHomePageViewController.swift; sourceTree = "<group>"; };
@@ -288,6 +290,7 @@
 			isa = PBXGroup;
 			children = (
 				BA00B73B2A46B98700BB3795 /* SnapKit+.swift */,
+				B21C1A8B2A513FBB007D98E9 /* RIBs+.swift */,
 			);
 			path = 3rdParty;
 			sourceTree = "<group>";
@@ -582,6 +585,7 @@
 			files = (
 				B282050A2A34700300F9242F /* EventHomeRouter.swift in Sources */,
 				B2F169E02A34D07F008199D8 /* CALayer+.swift in Sources */,
+				B21C1A8C2A513FBB007D98E9 /* RIBs+.swift in Sources */,
 				BA1807622A2F21D900295398 /* URLRequest+.swift in Sources */,
 				BA437F162A235F5100C5DFA8 /* LoggedOutRouter.swift in Sources */,
 				BAED88322A24C3E600DA6257 /* RootInteractor.swift in Sources */,

--- a/Pyonsnal-Color/Pyonsnal-Color/3rdParty/RIBs+.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/3rdParty/RIBs+.swift
@@ -1,0 +1,48 @@
+//
+//  RIBs+.swift
+//  Pyonsnal-Color
+//
+//  Created by 김인호 on 2023/07/02.
+//
+
+import UIKit
+import ModernRIBs
+
+final class NavigationControllable: ViewControllable {
+    
+    var uiviewController: UIViewController { self.navigationController }
+    let navigationController: UINavigationController
+    
+    init(root: ViewControllable) {
+        let navigationController = UINavigationController(rootViewController: root.uiviewController)
+        navigationController.isNavigationBarHidden = true
+        
+        self.navigationController = navigationController
+    }
+    
+}
+
+extension ViewControllable {
+    
+    func pushViewController(_ viewControllable: ViewControllable, animated: Bool) {
+        if let navigationController = uiviewController as? UINavigationController {
+            navigationController.pushViewController(
+                viewControllable.uiviewController,
+                animated: animated
+            )
+        } else {
+            uiviewController.navigationController?.pushViewController(
+                viewControllable.uiviewController,
+                animated: animated
+            )
+        }
+    }
+    
+    func popViewController(animated: Bool) {
+        if let navigationController = uiviewController as? UINavigationController {
+            navigationController.popViewController(animated: animated)
+        } else {
+            uiviewController.navigationController?.popViewController(animated: animated)
+        }
+    }
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/RootTabBar/RootTabBarRouter.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/RootTabBar/RootTabBarRouter.swift
@@ -52,16 +52,16 @@ final class RootTabBarRouter:
     func attachTabs() {
         let productHome = productHomeBuilder.build(withListener: interactor)
         let eventHome = eventHomeBuilder.build(withListener: interactor)
-        let profilHome = profileHomeBuilder.build(withListener: interactor)
+        let profileHome = profileHomeBuilder.build(withListener: interactor)
         
         attachChild(productHome)
         attachChild(eventHome)
-        attachChild(profilHome)
+        attachChild(profileHome)
         
         let viewControllers: [ViewControllable] = [
-            productHome.viewControllable,
-            eventHome.viewControllable,
-            profilHome.viewControllable
+            NavigationControllable(root: productHome.viewControllable),
+            NavigationControllable(root: eventHome.viewControllable),
+            NavigationControllable(root: profileHome.viewControllable)
         ]
         
         viewController.setViewControllers(viewControllers)


### PR DESCRIPTION
### 이슈
#37 

### 수정사항
- Push, Pop 구현을 위한 `NavigationControllalbe` 클래스 생성
  - `RIBs +`
  - 네비게이션 바 `hidden` 처리
  - `RootTabBar`의 각 탭에 적용

### `NavigationController` 적용 화면 (변화 없음,,)
|<img src="https://github.com/YAPP-Github/PyonsnalColor-iOS/assets/71054048/8356f33a-f661-4ab8-a687-7c47309a0d9a" width=250>|<img src="https://github.com/YAPP-Github/PyonsnalColor-iOS/assets/71054048/f26870a4-42df-438c-91d4-b28a64c7882c" width=250>|
|:-:|:-:|


