### PR TITLE
로그아웃 & 회원탈퇴 시 popup 구현

### DIFF
--- a/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
+++ b/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
@@ -42,6 +42,10 @@
 		B28205132A34702B00F9242F /* ProductHomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B282050F2A34702B00F9242F /* ProductHomeViewController.swift */; };
 		B28205142A34702B00F9242F /* ProductHomeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28205102A34702B00F9242F /* ProductHomeBuilder.swift */; };
 		B28205152A34702B00F9242F /* ProductHomeInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28205112A34702B00F9242F /* ProductHomeInteractor.swift */; };
+		B2A529492A57F2220010656A /* LogoutPopupRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A529452A57F2220010656A /* LogoutPopupRouter.swift */; };
+		B2A5294A2A57F2220010656A /* LogoutPopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A529462A57F2220010656A /* LogoutPopupViewController.swift */; };
+		B2A5294B2A57F2220010656A /* LogoutPopupBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A529472A57F2220010656A /* LogoutPopupBuilder.swift */; };
+		B2A5294C2A57F2220010656A /* LogoutPopupInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A529482A57F2220010656A /* LogoutPopupInteractor.swift */; };
 		B2A57BEB2A2C7596005DB83E /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = B2A57BEA2A2C7596005DB83E /* KakaoSDKAuth */; };
 		B2A57BED2A2C7596005DB83E /* KakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = B2A57BEC2A2C7596005DB83E /* KakaoSDKCommon */; };
 		B2A57BEF2A2C7596005DB83E /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = B2A57BEE2A2C7596005DB83E /* KakaoSDKUser */; };
@@ -164,6 +168,10 @@
 		B282050F2A34702B00F9242F /* ProductHomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductHomeViewController.swift; sourceTree = "<group>"; };
 		B28205102A34702B00F9242F /* ProductHomeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductHomeBuilder.swift; sourceTree = "<group>"; };
 		B28205112A34702B00F9242F /* ProductHomeInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductHomeInteractor.swift; sourceTree = "<group>"; };
+		B2A529452A57F2220010656A /* LogoutPopupRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoutPopupRouter.swift; sourceTree = "<group>"; };
+		B2A529462A57F2220010656A /* LogoutPopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoutPopupViewController.swift; sourceTree = "<group>"; };
+		B2A529472A57F2220010656A /* LogoutPopupBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoutPopupBuilder.swift; sourceTree = "<group>"; };
+		B2A529482A57F2220010656A /* LogoutPopupInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoutPopupInteractor.swift; sourceTree = "<group>"; };
 		B2A57C3E2A2EF917005DB83E /* KakaoLoginService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginService.swift; sourceTree = "<group>"; };
 		B2F169D52A347208008199D8 /* RootTabBarBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootTabBarBuilder.swift; sourceTree = "<group>"; };
 		B2F169D72A3472D7008199D8 /* RootTabBarInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootTabBarInteractor.swift; sourceTree = "<group>"; };
@@ -362,6 +370,17 @@
 			path = ProfileHome;
 			sourceTree = "<group>";
 		};
+		B2A529442A57F1E30010656A /* LogoutPopup */ = {
+			isa = PBXGroup;
+			children = (
+				B2A529452A57F2220010656A /* LogoutPopupRouter.swift */,
+				B2A529462A57F2220010656A /* LogoutPopupViewController.swift */,
+				B2A529472A57F2220010656A /* LogoutPopupBuilder.swift */,
+				B2A529482A57F2220010656A /* LogoutPopupInteractor.swift */,
+			);
+			path = LogoutPopup;
+			sourceTree = "<group>";
+		};
 		B2A57C3D2A2EF8FF005DB83E /* Service */ = {
 			isa = PBXGroup;
 			children = (
@@ -543,6 +562,7 @@
 		BA9E23392A21EF3000A539D5 /* Pyonsnal-Color */ = {
 			isa = PBXGroup;
 			children = (
+				B2A529442A57F1E30010656A /* LogoutPopup */,
 				F0C87AF12A51DFB800EA4C76 /* Model */,
 				F0EE10A62A4B387A00B8DF4F /* AccountSetting */,
 				BA00B73A2A46B95300BB3795 /* 3rdParty */,
@@ -823,6 +843,7 @@
 				BAEA1BF82A344D480028A90A /* LoggedOutViewController+ViewHolder.swift in Sources */,
 				B2A57C3F2A2EF917005DB83E /* KakaoLoginService.swift in Sources */,
 				F069DBE62A30B9850001D3DD /* UIFont+.swift in Sources */,
+				B2A529492A57F2220010656A /* LogoutPopupRouter.swift in Sources */,
 				B24F1D3C2A456C2400AA03DC /* UICollectionView+.swift in Sources */,
 				B2674D0D2A42DBCA004193DE /* ProductHomeViewHolder.swift in Sources */,
 				B24F1D4E2A4C5F2F00AA03DC /* NotificationCell.swift in Sources */,
@@ -846,6 +867,7 @@
 				BA87E3E02A462AD9000A9DEC /* ProductTagListView.swift in Sources */,
 				B28205142A34702B00F9242F /* ProductHomeBuilder.swift in Sources */,
 				F0C87AF02A51D74900EA4C76 /* NetworkError.swift in Sources */,
+				B2A5294C2A57F2220010656A /* LogoutPopupInteractor.swift in Sources */,
 				BA87E3CF2A45C5A1000A9DEC /* ProductDetailInteractor.swift in Sources */,
 				BA437F172A235F5100C5DFA8 /* LoggedOutViewController.swift in Sources */,
 				B24CAAE42A55AC2F005BE499 /* NotificationListInteractor.swift in Sources */,
@@ -865,6 +887,7 @@
 				B2538B932A34551D00B7C3F0 /* LoggedInRouter.swift in Sources */,
 				BA87E3DE2A4629B5000A9DEC /* ProductEntity.swift in Sources */,
 				BAED882F2A24C3E600DA6257 /* RootRouter.swift in Sources */,
+				B2A5294B2A57F2220010656A /* LogoutPopupBuilder.swift in Sources */,
 				BA87E3D52A45D400000A9DEC /* GiftItemView.swift in Sources */,
 				B2F169DE2A347995008199D8 /* RootTabBarComponent.swift in Sources */,
 				F0EE10AC2A4B389A00B8DF4F /* AccountSettingViewController.swift in Sources */,
@@ -878,6 +901,7 @@
 				B24F1D382A44171800AA03DC /* ProductHomePageViewController.swift in Sources */,
 				B28205022A346FDD00F9242F /* ProfileHomeRouter.swift in Sources */,
 				F01535452A45A6F800A2A8F2 /* ItemHeaderTitleView.swift in Sources */,
+				B2A5294A2A57F2220010656A /* LogoutPopupViewController.swift in Sources */,
 				B2538B942A34551D00B7C3F0 /* LoggedInBuilder.swift in Sources */,
 				B28205122A34702B00F9242F /* ProductHomeRouter.swift in Sources */,
 				B282050B2A34700300F9242F /* EventHomeViewController.swift in Sources */,

--- a/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,7 +3,7 @@
     {
       "identity" : "alamofire",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Alamofire/Alamofire",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
       "state" : {
         "revision" : "bc268c28fb170f494de9e9927c371b8342979ece",
         "version" : "5.7.1"

--- a/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,7 +3,7 @@
     {
       "identity" : "alamofire",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "location" : "https://github.com/Alamofire/Alamofire",
       "state" : {
         "revision" : "bc268c28fb170f494de9e9927c371b8342979ece",
         "version" : "5.7.1"

--- a/Pyonsnal-Color/Pyonsnal-Color/AccountSetting/AccountSettingBuilder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/AccountSetting/AccountSettingBuilder.swift
@@ -12,7 +12,7 @@ protocol AccountSettingDependency: Dependency {
     // created by this RIB.
 }
 
-final class AccountSettingComponent: Component<AccountSettingDependency> {
+final class AccountSettingComponent: Component<AccountSettingDependency>, LogoutPopupDependency {
 
     // TODO: Declare 'fileprivate' dependencies that are only used by this RIB.
 }
@@ -34,7 +34,11 @@ final class AccountSettingBuilder: Builder<AccountSettingDependency>, AccountSet
         let viewController = AccountSettingViewController()
         let interactor = AccountSettingInteractor(presenter: viewController)
         interactor.listener = listener
-        return AccountSettingRouter(interactor: interactor,
-                                    viewController: viewController)
+        let logoutPopupBuilder = LogoutPopupBuilder(dependency: component)
+        return AccountSettingRouter(
+            interactor: interactor,
+            viewController: viewController,
+            logoutPopupBuilder: logoutPopupBuilder
+        )
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/AccountSetting/AccountSettingInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/AccountSetting/AccountSettingInteractor.swift
@@ -8,7 +8,8 @@
 import ModernRIBs
 
 protocol AccountSettingRouting: ViewableRouting {
-    // TODO: Declare methods the interactor can invoke to manage sub-tree via the router.
+    func attachPopup(isLogout: Bool)
+    func detachPopup()
 }
 
 protocol AccountSettingPresentable: Presentable {
@@ -44,5 +45,17 @@ final class AccountSettingInteractor: PresentableInteractor<AccountSettingPresen
     
     func didTapBackButton() {
         listener?.didTapBackButton()
+    }
+    
+    func didTapLogoutButton() {
+        router?.attachPopup(isLogout: true)
+    }
+    
+    func didTapDeleteAccountButton() {
+        router?.attachPopup(isLogout: false)
+    }
+    
+    func popupDidTabDismissButton() {
+        router?.detachPopup()
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/AccountSetting/AccountSettingViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/AccountSetting/AccountSettingViewController.swift
@@ -10,6 +10,8 @@ import UIKit
 
 protocol AccountSettingPresentableListener: AnyObject {
     func didTapBackButton()
+    func didTapDeleteAccountButton()
+    func didTapLogoutButton()
 }
 
 final class AccountSettingViewController: UIViewController,
@@ -23,6 +25,10 @@ final class AccountSettingViewController: UIViewController,
         static var cellTotalHeight: CGFloat {
             return rows * cellHeight
         }
+    }
+    
+    enum Index {
+        static let logout: Int = 1
     }
     
     weak var listener: AccountSettingPresentableListener?
@@ -68,13 +74,15 @@ final class AccountSettingViewController: UIViewController,
     
     @objc
     private func didTapDeleteAccountButton() {
-        // TO DO : 회원 탈퇴 로직
+        listener?.didTapDeleteAccountButton()
     }
 }
 
 extension AccountSettingViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        print(accountSettingData[indexPath.row])
+        if indexPath.row == Index.logout {
+            listener?.didTapLogoutButton()
+        }
     }
 }
 

--- a/Pyonsnal-Color/Pyonsnal-Color/Extension/UIButton+.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Extension/UIButton+.swift
@@ -48,4 +48,12 @@ extension UIButton {
         }
         self.setAttributedTitle(attributedText, for: .normal)
     }
+    
+    func setCustomFont(text: String, color: UIColor, font: UIFont) {
+        let attributedString = NSMutableAttributedString(string: text)
+        let range = (text as NSString).range(of: text)
+        attributedString.addAttribute(.foregroundColor, value: color, range: range)
+        attributedString.addAttribute(.font, value: font, range: range)
+        setAttributedTitle(attributedString, for: .normal)
+    }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/LogoutPopup/LogoutPopupBuilder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/LogoutPopup/LogoutPopupBuilder.swift
@@ -1,0 +1,48 @@
+//
+//  LogoutPopupBuilder.swift
+//  Pyonsnal-Color
+//
+//  Created by 김인호 on 2023/07/07.
+//
+
+import ModernRIBs
+
+protocol LogoutPopupDependency: Dependency {
+    // TODO: Declare the set of dependencies required by this RIB, but cannot be
+    // created by this RIB.
+}
+
+final class LogoutPopupComponent: Component<LogoutPopupDependency> {
+
+    // TODO: Declare 'fileprivate' dependencies that are only used by this RIB.
+}
+
+// MARK: - Builder
+
+protocol LogoutPopupBuildable: Buildable {
+    func build(withListener listener: LogoutPopupListener) -> LogoutPopupRouting
+    func build(withListener listener: LogoutPopupListener, isLogout: Bool) -> LogoutPopupRouting
+}
+
+final class LogoutPopupBuilder: Builder<LogoutPopupDependency>, LogoutPopupBuildable {
+
+    override init(dependency: LogoutPopupDependency) {
+        super.init(dependency: dependency)
+    }
+
+    func build(withListener listener: LogoutPopupListener) -> LogoutPopupRouting {
+        let component = LogoutPopupComponent(dependency: dependency)
+        let viewController = LogoutPopupViewController()
+        let interactor = LogoutPopupInteractor(presenter: viewController)
+        interactor.listener = listener
+        return LogoutPopupRouter(interactor: interactor, viewController: viewController)
+    }
+    
+    func build(withListener listener: LogoutPopupListener, isLogout: Bool) -> LogoutPopupRouting {
+        let component = LogoutPopupComponent(dependency: dependency)
+        let viewController = LogoutPopupViewController(isLogout: isLogout)
+        let interactor = LogoutPopupInteractor(presenter: viewController)
+        interactor.listener = listener
+        return LogoutPopupRouter(interactor: interactor, viewController: viewController)
+    }
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/LogoutPopup/LogoutPopupInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/LogoutPopup/LogoutPopupInteractor.swift
@@ -1,0 +1,62 @@
+//
+//  LogoutPopupInteractor.swift
+//  Pyonsnal-Color
+//
+//  Created by 김인호 on 2023/07/07.
+//
+
+import ModernRIBs
+
+protocol LogoutPopupRouting: ViewableRouting {
+}
+
+protocol LogoutPopupPresentable: Presentable {
+    var listener: LogoutPopupPresentableListener? { get set }
+}
+
+protocol LogoutPopupListener: AnyObject {
+    func popupDidTabDismissButton()
+}
+
+final class LogoutPopupInteractor:
+    PresentableInteractor<LogoutPopupPresentable>,
+    LogoutPopupInteractable,
+    LogoutPopupPresentableListener {
+
+    enum Text {
+        static let dismiss: String = "취소하기"
+    }
+
+    weak var router: LogoutPopupRouting?
+    weak var listener: LogoutPopupListener?
+
+    override init(presenter: LogoutPopupPresentable) {
+        super.init(presenter: presenter)
+        presenter.listener = self
+    }
+
+    override func didBecomeActive() {
+        super.didBecomeActive()
+    }
+
+    override func willResignActive() {
+        super.willResignActive()
+    }
+    
+    func didTabDismissButton(_ text: String?) {
+        if let text, text == Text.dismiss {
+            listener?.popupDidTabDismissButton()
+        } else {
+            
+        }
+    }
+    
+    func didTabConfirmButton(_ text: String?) {
+        if let text, text == Text.dismiss {
+            listener?.popupDidTabDismissButton()
+        } else {
+            
+        }
+    }
+    
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/LogoutPopup/LogoutPopupInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/LogoutPopup/LogoutPopupInteractor.swift
@@ -47,7 +47,7 @@ final class LogoutPopupInteractor:
         if let text, text == Text.dismiss {
             listener?.popupDidTabDismissButton()
         } else {
-            
+            // TODO: 로그아웃 로직 구현
         }
     }
     
@@ -55,7 +55,7 @@ final class LogoutPopupInteractor:
         if let text, text == Text.dismiss {
             listener?.popupDidTabDismissButton()
         } else {
-            
+            // TODO: 회원탈퇴 로직 구현
         }
     }
     

--- a/Pyonsnal-Color/Pyonsnal-Color/LogoutPopup/LogoutPopupRouter.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/LogoutPopup/LogoutPopupRouter.swift
@@ -1,0 +1,26 @@
+//
+//  LogoutPopupRouter.swift
+//  Pyonsnal-Color
+//
+//  Created by 김인호 on 2023/07/07.
+//
+
+import ModernRIBs
+
+protocol LogoutPopupInteractable: Interactable {
+    var router: LogoutPopupRouting? { get set }
+    var listener: LogoutPopupListener? { get set }
+}
+
+protocol LogoutPopupViewControllable: ViewControllable {
+    // TODO: Declare methods the router invokes to manipulate the view hierarchy.
+}
+
+final class LogoutPopupRouter: ViewableRouter<LogoutPopupInteractable, LogoutPopupViewControllable>, LogoutPopupRouting {
+
+    // TODO: Constructor inject child builder protocols to allow building children.
+    override init(interactor: LogoutPopupInteractable, viewController: LogoutPopupViewControllable) {
+        super.init(interactor: interactor, viewController: viewController)
+        interactor.router = self
+    }
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/LogoutPopup/LogoutPopupViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/LogoutPopup/LogoutPopupViewController.swift
@@ -1,0 +1,240 @@
+//
+//  LogoutPopupViewController.swift
+//  Pyonsnal-Color
+//
+//  Created by 김인호 on 2023/07/07.
+//
+
+import ModernRIBs
+import SnapKit
+import UIKit
+
+protocol LogoutPopupPresentableListener: AnyObject {
+    func didTabDismissButton(_ text: String?)
+    func didTabConfirmButton(_ text: String?)
+}
+
+final class LogoutPopupViewController:
+    UIViewController,
+    LogoutPopupPresentable,
+    LogoutPopupViewControllable {
+    
+    enum Text {
+        enum Logout {
+            static let title: String = "로그아웃 하시겠어요?"
+            static let description: String = "다음에 또 편스널컬러를 찾아주세요!"
+            static let dismissButtonText: String = "취소하기"
+            static let confirmButtonText: String = "로그아웃 하기"
+        }
+        
+        enum DeleteAccount {
+            static let title: String = "정말 탈퇴하시겠어요?"
+            static let description: String = "탈퇴하시면 앱 내 모든 데이터가 사라지게 돼요."
+            static let dismissButtonText: String = "회원탈퇴"
+            static let confirmButtonText: String = "취소하기"
+        }
+    }
+
+    weak var listener: LogoutPopupPresentableListener?
+        
+    private let viewHolder: ViewHolder = .init()
+    
+    convenience init(isLogout: Bool) {
+        self.init()
+
+        configureText(isLogout: isLogout)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        viewHolder.place(in: view)
+        viewHolder.configureConstraints(for: view)
+        configureView()
+        configureAction()
+    }
+    
+    private func configureView() {
+        view.backgroundColor = .black.withAlphaComponent(0.5)
+    }
+    
+    private func configureText(isLogout: Bool) {
+        if isLogout {
+            viewHolder.titleLabel.text = Text.Logout.title
+            viewHolder.descriptionLabel.text = Text.Logout.description
+            viewHolder.dismissButton.setAttributedTitle(
+                text: Text.Logout.dismissButtonText,
+                color: .black,
+                font: .body2m
+            )
+            viewHolder.confirmButton.setAttributedTitle(
+                text: Text.Logout.confirmButtonText,
+                color: .red500,
+                font: .body2m
+            )
+        } else {
+            viewHolder.titleLabel.text = Text.DeleteAccount.title
+            viewHolder.descriptionLabel.text = Text.DeleteAccount.description
+            viewHolder.dismissButton.setAttributedTitle(
+                text: Text.DeleteAccount.dismissButtonText,
+                color: .black,
+                font: .body2m
+            )
+            viewHolder.confirmButton.setAttributedTitle(
+                text: Text.DeleteAccount.confirmButtonText,
+                color: .red500,
+                font: .body2m
+            )
+        }
+    }
+    
+    private func configureAction() {
+        viewHolder.dismissButton.addTarget(
+            self,
+            action: #selector(didTabDismissButton(_:)),
+            for: .touchUpInside
+        )
+        viewHolder.confirmButton.addTarget(
+            self,
+            action: #selector(didTabConfirmButton(_:)),
+            for: .touchUpInside
+        )
+    }
+    
+    @objc func didTabDismissButton(_ sender: UIButton) {
+        listener?.didTabDismissButton(sender.titleLabel?.text)
+    }
+    
+    @objc func didTabConfirmButton(_ sender: UIButton) {
+        listener?.didTabConfirmButton(sender.titleLabel?.text)
+    }
+}
+
+extension LogoutPopupViewController {
+    final class ViewHolder: ViewHolderable {
+        
+        enum Constant {
+            enum Size {
+                static let topBottomMargin: CGFloat = 40
+                static let leftRightMargin: CGFloat = 20
+                static let titleStackViewSpacing: CGFloat = Spacing.spacing8.value
+                static let buttonStackViewSpacing: CGFloat = Spacing.spacing16.value
+                static let popupWidth: CGFloat = 358
+                static let popupHeight: CGFloat = 228
+                static let buttonWidth: CGFloat = 151
+                static let buttonHeight: CGFloat = 52
+            }
+        }
+        
+        private let containerView: UIView = .init(frame: .zero)
+        
+        private let mainPopupView: UIView = {
+            let view = UIView()
+            view.makeRounded(with: Spacing.spacing16.value)
+            view.backgroundColor = .white
+            return view
+        }()
+        
+        private let textStackView: UIStackView = {
+            let stackView = UIStackView()
+            stackView.axis = .vertical
+            stackView.spacing = Constant.Size.titleStackViewSpacing
+            stackView.alignment = .center
+            return stackView
+        }()
+        
+        let titleLabel: UILabel = {
+            let label = UILabel()
+            label.font = .title1
+            label.textColor = .black
+            return label
+        }()
+        
+        let descriptionLabel: UILabel = {
+            let label = UILabel()
+            label.font = .body2r
+            label.textColor = .init(rgbHexString: "#808084")
+            return label
+        }()
+        
+        private let buttonStackView: UIStackView = {
+            let stackView = UIStackView()
+            stackView.axis = .horizontal
+            stackView.spacing = Constant.Size.buttonStackViewSpacing
+            stackView.alignment = .center
+            return stackView
+        }()
+        
+        let dismissButton: UIButton = {
+            let button = UIButton()
+            button.makeBorder(width: 1, color: UIColor.black.cgColor)
+            button.makeRounded(with: Spacing.spacing16.value)
+
+            return button
+        }()
+        
+        let confirmButton: UIButton = {
+            let button = UIButton()
+            button.makeBorder(width: 1, color: UIColor.black.cgColor)
+            button.makeRounded(with: Spacing.spacing16.value)
+            button.backgroundColor = .black
+            return button
+        }()
+        
+        func place(in view: UIView) {
+            view.addSubview(containerView)
+            
+            containerView.addSubview(mainPopupView)
+            
+            mainPopupView.addSubview(textStackView)
+            mainPopupView.addSubview(buttonStackView)
+            
+            textStackView.addArrangedSubview(titleLabel)
+            textStackView.addArrangedSubview(descriptionLabel)
+            
+            buttonStackView.addArrangedSubview(dismissButton)
+            buttonStackView.addArrangedSubview(confirmButton)
+        }
+        
+        func configureConstraints(for view: UIView) {
+            containerView.snp.makeConstraints { make in
+                make.edges.equalTo(view.safeAreaLayoutGuide)
+            }
+            
+            mainPopupView.snp.makeConstraints { make in
+                make.centerX.centerY.equalToSuperview()
+                make.width.equalTo(Constant.Size.popupWidth)
+                make.height.equalTo(Constant.Size.popupHeight)
+            }
+            
+            textStackView.snp.makeConstraints { make in
+                make.top.equalToSuperview().offset(Constant.Size.topBottomMargin)
+                make.centerX.equalToSuperview()
+            }
+            
+            buttonStackView.snp.makeConstraints { make in
+                make.bottom.equalToSuperview().inset(Constant.Size.topBottomMargin)
+                make.centerX.equalToSuperview()
+            }
+            
+            titleLabel.snp.makeConstraints { make in
+                make.height.equalTo(titleLabel.font.customLineHeight)
+            }
+            
+            descriptionLabel.snp.makeConstraints { make in
+                make.height.equalTo(titleLabel.font.customLineHeight)
+            }
+            
+            dismissButton.snp.makeConstraints { make in
+                make.width.equalTo(Constant.Size.buttonWidth)
+                make.height.equalTo(Constant.Size.buttonHeight)
+            }
+            
+            confirmButton.snp.makeConstraints { make in
+                make.width.equalTo(Constant.Size.buttonWidth)
+                make.height.equalTo(Constant.Size.buttonHeight)
+            }
+        }
+
+    }
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/LogoutPopup/LogoutPopupViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/LogoutPopup/LogoutPopupViewController.swift
@@ -62,12 +62,12 @@ final class LogoutPopupViewController:
         if isLogout {
             viewHolder.titleLabel.text = Text.Logout.title
             viewHolder.descriptionLabel.text = Text.Logout.description
-            viewHolder.dismissButton.setAttributedTitle(
+            viewHolder.dismissButton.setCustomFont(
                 text: Text.Logout.dismissButtonText,
                 color: .black,
                 font: .body2m
             )
-            viewHolder.confirmButton.setAttributedTitle(
+            viewHolder.confirmButton.setCustomFont(
                 text: Text.Logout.confirmButtonText,
                 color: .red500,
                 font: .body2m
@@ -75,12 +75,12 @@ final class LogoutPopupViewController:
         } else {
             viewHolder.titleLabel.text = Text.DeleteAccount.title
             viewHolder.descriptionLabel.text = Text.DeleteAccount.description
-            viewHolder.dismissButton.setAttributedTitle(
+            viewHolder.dismissButton.setCustomFont(
                 text: Text.DeleteAccount.dismissButtonText,
                 color: .black,
                 font: .body2m
             )
-            viewHolder.confirmButton.setAttributedTitle(
+            viewHolder.confirmButton.setCustomFont(
                 text: Text.DeleteAccount.confirmButtonText,
                 color: .red500,
                 font: .body2m

--- a/Pyonsnal-Color/Pyonsnal-Color/ProfileHome/ProfileHomeRouter.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProfileHome/ProfileHomeRouter.swift
@@ -41,7 +41,7 @@ final class ProfileHomeRouter: ViewableRouter<ProfileHomeInteractable,
         accountSetting = accountSettingRouter
         attachChild(accountSettingRouter)
         let accountSettingViewController = accountSettingRouter.viewControllable.uiviewController
-        viewController.uiviewController.modalPresentationStyle = .fullScreen
+        accountSettingViewController.modalPresentationStyle = .fullScreen
         viewController.uiviewController.present(accountSettingViewController, animated: true)
     }
     


### PR DESCRIPTION
### 이슈
#51 

### 수정사항
- 화면을 구현하기 위해 `logoutPopup`리블렛을 만들고, 배경에 색과 투명도를 조절하여 팝업처럼 보이게 구현하였습니다.
- 현재는 로그아웃 & 회원탈퇴 모두 같은 팝업 창을 띄워줘서 하나의 리블렛에 `convenience init()`을 활용하여 컨텐츠를 다르게 보여줍니다.
(제목, 설명, 버튼 텍스트 등)
- 두 화면에서 모두 `취소하기`를 누를 시에만 화면이 사라집니다.

###  스크린샷
![Simulator Screen Recording - iPhone 14 Pro - 2023-07-08 at 11 43 07](https://github.com/YAPP-Github/PyonsnalColor-iOS/assets/71054048/765ed4a4-3778-405c-a0d5-21fe55744650)

