### PR TITLE
자동 로그인 구현

### DIFF
--- a/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
+++ b/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		BA437F212A2360E100C5DFA8 /* AppComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA437F202A2360E100C5DFA8 /* AppComponent.swift */; };
 		BA4818CD2A59405300BF9CAD /* AuthAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4818CC2A59405300BF9CAD /* AuthAPIService.swift */; };
 		BA4818CF2A59410B00BF9CAD /* UserAuthEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4818CE2A59410B00BF9CAD /* UserAuthEntity.swift */; };
+		BA7532E22A595B140002659A /* UserAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7532E12A595B140002659A /* UserAuthService.swift */; };
 		BA87501C2A519A9200B80088 /* ImageAssetKind+StoreIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA87501B2A519A9200B80088 /* ImageAssetKind+StoreIcon.swift */; };
 		BA87501E2A519B3900B80088 /* ImageAssetKind+HeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA87501D2A519B3900B80088 /* ImageAssetKind+HeaderView.swift */; };
 		BA87E3CC2A45C5A1000A9DEC /* ProductDetailRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA87E3C82A45C5A1000A9DEC /* ProductDetailRouter.swift */; };
@@ -215,6 +216,7 @@
 		BA437F202A2360E100C5DFA8 /* AppComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppComponent.swift; sourceTree = "<group>"; };
 		BA4818CC2A59405300BF9CAD /* AuthAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPIService.swift; sourceTree = "<group>"; };
 		BA4818CE2A59410B00BF9CAD /* UserAuthEntity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserAuthEntity.swift; sourceTree = "<group>"; };
+		BA7532E12A595B140002659A /* UserAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAuthService.swift; sourceTree = "<group>"; };
 		BA87501B2A519A9200B80088 /* ImageAssetKind+StoreIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ImageAssetKind+StoreIcon.swift"; sourceTree = "<group>"; };
 		BA87501D2A519B3900B80088 /* ImageAssetKind+HeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ImageAssetKind+HeaderView.swift"; sourceTree = "<group>"; };
 		BA87E3C82A45C5A1000A9DEC /* ProductDetailRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailRouter.swift; sourceTree = "<group>"; };
@@ -429,6 +431,7 @@
 				F0964E412A2A44500028DCA2 /* KeyChainService.swift */,
 				F02C8DA62A2E149700593A2D /* AppleLoginService.swift */,
 				B2A57C3E2A2EF917005DB83E /* KakaoLoginService.swift */,
+				BA7532E12A595B140002659A /* UserAuthService.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -942,6 +945,7 @@
 				BA437F182A235F5100C5DFA8 /* LoggedOutBuilder.swift in Sources */,
 				F01535432A45A69800A2A8F2 /* EventHomeSectionLayout.swift in Sources */,
 				F0964E422A2A44500028DCA2 /* KeyChainService.swift in Sources */,
+				BA7532E22A595B140002659A /* UserAuthService.swift in Sources */,
 				BA8924562A582EE700D1B097 /* NewTagBigView.swift in Sources */,
 				F0687BED2A529679004B5EAE /* Config.swift in Sources */,
 				B28205032A346FDD00F9242F /* ProfileHomeViewController.swift in Sources */,

--- a/Pyonsnal-Color/Pyonsnal-Color/Application/AppComponent.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Application/AppComponent.swift
@@ -8,6 +8,7 @@
 import ModernRIBs
 
 final class AppComponent: Component<EmptyDependency>, RootDependency {
+    let userAuthService: UserAuthService = .init(keyChainService: .shared)
     init() {
         super.init(dependency: EmptyComponent())
     }

--- a/Pyonsnal-Color/Pyonsnal-Color/LoggedOut/LoggedOutBuilder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/LoggedOut/LoggedOutBuilder.swift
@@ -11,6 +11,7 @@ protocol LoggedOutDependency: Dependency {
     var appleLoginService: AppleLoginService { get }
     var kakaoLoginService: KakaoLoginService { get }
     var authClient: AuthAPIService { get }
+    var userAuthService: UserAuthService { get }
 }
 
 final class LoggedOutComponent: Component<LoggedOutDependency>,

--- a/Pyonsnal-Color/Pyonsnal-Color/LoggedOut/LoggedOutInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/LoggedOut/LoggedOutInteractor.swift
@@ -107,6 +107,7 @@ final class LoggedOutInteractor:
     
     func termsOfUseCloseButtonDidTap() {
         loginTask = nil
+        router?.detachTermsOfUse()
     }
     
     func termsOfUseAcceptButtonDidTap() {

--- a/Pyonsnal-Color/Pyonsnal-Color/Root/RootBuilder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Root/RootBuilder.swift
@@ -8,6 +8,7 @@
 import ModernRIBs
 
 protocol RootDependency: Dependency {
+    var userAuthService: UserAuthService { get }
 }
 
 // MARK: - Builder
@@ -28,7 +29,7 @@ final class RootBuilder: Builder<RootDependency>, RootBuildable {
             rootViewController: viewController,
             dependency: dependency
         )
-        let interactor: RootInteractor = .init(presenter: viewController)
+        let interactor: RootInteractor = .init(presenter: viewController, dependency: dependency)
         let loggedOutBuilder: LoggedOutBuilder = .init(dependency: component)
         let loggedInBuilder: LoggedInBuilder = .init(dependency: component)
         let router: RootRouter = .init(

--- a/Pyonsnal-Color/Pyonsnal-Color/Root/RootComponent.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Root/RootComponent.swift
@@ -15,6 +15,7 @@ final class RootComponent: Component<RootDependency> {
     let rootViewController: RootViewController
     var appleLoginService: AppleLoginService
     var kakaoLoginService: KakaoLoginService
+    let userAuthService: UserAuthService
     var authClient: AuthAPIService
     
     init(rootViewController: RootViewController,
@@ -23,6 +24,8 @@ final class RootComponent: Component<RootDependency> {
         self.rootViewController = rootViewController
         self.appleLoginService = AppleLoginService()
         self.kakaoLoginService = KakaoLoginService()
+        let keyChainService = KeyChainService.shared
+        self.userAuthService = .init(keyChainService: keyChainService)
         let pyonsnalColorClient = PyonsnalColorClient()
         self.authClient = .init(client: pyonsnalColorClient)
         super.init(dependency: dependency)

--- a/Pyonsnal-Color/Pyonsnal-Color/Root/RootInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Root/RootInteractor.swift
@@ -9,6 +9,7 @@ import ModernRIBs
 
 protocol RootRouting: ViewableRouting {
     func routeToLoggedIn()
+    func routeToLoggedOut()
 }
 
 protocol RootPresentable: Presentable {
@@ -25,8 +26,11 @@ final class RootInteractor:
 
     weak var router: RootRouting?
     weak var listener: RootListener?
+    
+    private let dependency: RootDependency
 
-    override init(presenter: RootPresentable) {
+    init(presenter: RootPresentable, dependency: RootDependency) {
+        self.dependency = dependency
         super.init(presenter: presenter)
         presenter.listener = self
     }
@@ -41,5 +45,14 @@ final class RootInteractor:
     
     func routeToLoggedIn() {
         router?.routeToLoggedIn()
+    }
+    
+    func checkLoginedIn() {
+        if let accessToken = dependency.userAuthService.getAccessToken() {
+            print("Access Token: \(accessToken)")
+            router?.routeToLoggedIn()
+        } else {
+            router?.routeToLoggedOut()
+        }
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/Root/RootInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Root/RootInteractor.swift
@@ -37,6 +37,8 @@ final class RootInteractor:
 
     override func didBecomeActive() {
         super.didBecomeActive()
+        
+        checkLoginedIn()
     }
 
     override func willResignActive() {

--- a/Pyonsnal-Color/Pyonsnal-Color/Root/RootRouter.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Root/RootRouter.swift
@@ -41,12 +41,6 @@ final class RootRouter: LaunchRouter<RootInteractable, RootViewControllable>, Ro
         interactor.router = self
     }
 
-    override func didLoad() {
-        super.didLoad()
-
-        routeToLoggedOut()
-    }
-
     func routeToLoggedOut() {
         let loggedOut = loggedOutBuilder.build(withListener: interactor)
         self.loggedOut = loggedOut

--- a/Pyonsnal-Color/Pyonsnal-Color/Root/RootViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Root/RootViewController.swift
@@ -9,6 +9,7 @@ import ModernRIBs
 import UIKit
 
 protocol RootPresentableListener: AnyObject {
+    func checkLoginedIn()
 }
 
 final class RootViewController: UIViewController, RootPresentable, RootViewControllable {
@@ -62,9 +63,15 @@ final class RootViewController: UIViewController, RootPresentable, RootViewContr
 
         view.backgroundColor = .white
         configureUI()
+        
+        checkLoginedIn()
     }
 
     // MARK: - Private Method
+    private func checkLoginedIn() {
+        listener?.checkLoginedIn()
+    }
+    
     private func presentTargetViewController() {
         if let targetViewController {
             animationInProgress = true

--- a/Pyonsnal-Color/Pyonsnal-Color/Root/RootViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Root/RootViewController.swift
@@ -63,14 +63,9 @@ final class RootViewController: UIViewController, RootPresentable, RootViewContr
 
         view.backgroundColor = .white
         configureUI()
-        
-        checkLoginedIn()
     }
 
     // MARK: - Private Method
-    private func checkLoginedIn() {
-        listener?.checkLoginedIn()
-    }
     
     private func presentTargetViewController() {
         if let targetViewController {

--- a/Pyonsnal-Color/Pyonsnal-Color/Service/KeyChainService.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Service/KeyChainService.swift
@@ -25,8 +25,8 @@ final class KeyChainService: NSObject {
     static let shared = KeyChainService()
     private override init() {}
     
-    func addToken(token: String, to key: String) -> Bool {
-        guard let tokenData = token.data(using: .utf8) else { return false }
+    func set(value: String, to key: String) -> Bool {
+        guard let tokenData = value.data(using: .utf8) else { return false }
         let query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrService : key,
@@ -37,7 +37,7 @@ final class KeyChainService: NSObject {
         return status == errSecSuccess
     }
     
-    func getToken(with key: String) -> String? {
+    func get(with key: String) -> String? {
         let query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrService : key,
@@ -56,7 +56,7 @@ final class KeyChainService: NSObject {
         return nil
     }
     
-    func deleteToken(with key: String) -> Bool {
+    func delete(with key: String) -> Bool {
         let query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrService : key,

--- a/Pyonsnal-Color/Pyonsnal-Color/Service/UserAuthService.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Service/UserAuthService.swift
@@ -1,0 +1,36 @@
+//
+//  UserAuthService.swift
+//  Pyonsnal-Color
+//
+//  Created by 김진우 on 2023/07/08.
+//
+
+final class UserAuthService {
+    
+    // MARK: - Private Property
+    private let accessTokenKey: String = "UserAuthService.AccessToken.Key"
+//    private let refreshTokenKey: String = "UserAuthService.RefreshToken.Key"
+    private let keyChainService: KeyChainService
+    
+    // MARK: - Initializer
+    init(keyChainService: KeyChainService) {
+        self.keyChainService = keyChainService
+    }
+    
+    // MARK: - Interface
+    func getAccessToken() -> String? {
+        keyChainService.get(with: accessTokenKey)
+    }
+    
+    func setAccessToken(_ token: String) {
+        _ = keyChainService.set(value: token, to: accessTokenKey)
+    }
+    
+//    func refreshToken() -> String? {
+//        keyChainService.get(with: refreshTokenKey)
+//    }
+    
+//    func setRefreshToken(_ token: String) {
+//        _ = keyChainService.set(value: token, to: refreshTokenKey)
+//    }
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/TermsOfUse/TermsOfUseInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/TermsOfUse/TermsOfUseInteractor.swift
@@ -18,8 +18,8 @@ protocol TermsOfUsePresentable: Presentable {
 }
 
 protocol TermsOfUseListener: AnyObject {
-    func detachTermsOfUse()
-    func routeToLoggedIn()
+    func termsOfUseCloseButtonDidTap()
+    func termsOfUseAcceptButtonDidTap()
 }
 
 final class TermsOfUseInteractor: PresentableInteractor<TermsOfUsePresentable>, TermsOfUseInteractable, TermsOfUsePresentableListener {
@@ -46,13 +46,13 @@ final class TermsOfUseInteractor: PresentableInteractor<TermsOfUsePresentable>, 
     }
     
     func dismissViewController() {
-        listener?.detachTermsOfUse()
+        listener?.termsOfUseCloseButtonDidTap()
     }
     
     func routeToLoggedInIfNeeded() {
         // 로그인 request with 어떤 로그인 버튼 클릭했는지랑
         // 토큰 저장
-        listener?.routeToLoggedIn()
+        listener?.termsOfUseAcceptButtonDidTap()
     }
     
     func routeToWebView(subTermsInfo: SubTerms) {

--- a/Pyonsnal-Color/Pyonsnal-Color/TermsOfUse/TermsOfUseViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/TermsOfUse/TermsOfUseViewController.swift
@@ -22,7 +22,7 @@ final class TermsOfUseViewController: UIViewController,
     enum Constants {
         enum Text {
             static let allAgree = "모두 동의"
-            static let join = "가입완료"
+            static let acceptButtonTitle = "가입완료"
             static let title = "서비스 이용에 동의해주세요."
         }
         enum Size {
@@ -33,7 +33,7 @@ final class TermsOfUseViewController: UIViewController,
             static let allAggreeButtonTop: CGFloat = 40
             static let termsButtonHeight: CGFloat = 40
             static let dividerHeight: CGFloat = 1
-            static let joinButtonHeight: CGFloat = 52
+            static let acceptButtonHeight: CGFloat = 52
         }
     }
     
@@ -70,8 +70,8 @@ final class TermsOfUseViewController: UIViewController,
         viewHolder.allAgreeButton.addTarget(self,
                                             action: #selector(didTapAllAgreeButton),
                                             for: .touchUpInside)
-        viewHolder.joinButton.addTarget(self,
-                                        action: #selector(didTapJoinButton),
+        viewHolder.acceptButton.addTarget(self,
+                                        action: #selector(didTapAcceptButton),
                                         for: .touchUpInside)
         
         for subTermsButton in viewHolder.subTermsButtons {
@@ -110,8 +110,8 @@ final class TermsOfUseViewController: UIViewController,
         viewHolder.subTermsButtons.forEach { subTermsButton in
             subTermsButton.setButtonState(isSelected: toggledSelected)
         }
-        // set joinButton
-        setJoinButtonState(with: toggledSelected)
+        // set acceptButton
+        setAcceptButtonState(with: toggledSelected)
     }
     
     @objc
@@ -124,10 +124,10 @@ final class TermsOfUseViewController: UIViewController,
         //set allAgreeButton
         viewHolder.allAgreeButton.setButtonState(isSelected: isAllSubTermsButtonSelected)
         
-        // set joinButton
+        // set acceptButton
         let allAgreeButtonState = viewHolder.allAgreeButton.isCurrentSelected()
-        let joinButtonState = isAllSubTermsButtonSelected && allAgreeButtonState
-        setJoinButtonState(with: joinButtonState)
+        let acceptButtonState = isAllSubTermsButtonSelected && allAgreeButtonState
+        setAcceptButtonState(with: acceptButtonState)
     }
     
     @objc
@@ -137,13 +137,13 @@ final class TermsOfUseViewController: UIViewController,
     }
     
     @objc
-    private func didTapJoinButton() {
+    private func didTapAcceptButton() {
         listener?.routeToLoggedInIfNeeded()
     }
     
-    private func setJoinButtonState(with isAllSelected: Bool) {
+    private func setAcceptButtonState(with isAllSelected: Bool) {
         let buttonEnabled: PrimaryButton.ButtonSelectable = isAllSelected ? .enabled : .disabled
-        viewHolder.joinButton.setState(with: buttonEnabled)
+        viewHolder.acceptButton.setState(with: buttonEnabled)
     }
     
 }
@@ -251,10 +251,10 @@ extension TermsOfUseViewController {
             return button
         }()
         
-        // MARK: joinButton
-        let joinButton: PrimaryButton = {
+        // MARK: acceptButton
+        let acceptButton: PrimaryButton = {
             let button = PrimaryButton(state: .disabled)
-            button.setText(with: Constants.Text.join)
+            button.setText(with: Constants.Text.acceptButtonTitle)
             return button
         }()
         
@@ -270,7 +270,7 @@ extension TermsOfUseViewController {
             popUpView.addSubview(dividerView)
             
             popUpView.addSubview(subButtonVerticalStackView)
-            popUpView.addSubview(joinButton)
+            popUpView.addSubview(acceptButton)
             for (index, subTerm) in subTerms.enumerated() {
                 
                 //매번 생성 필요하여 여기에서 생성
@@ -345,10 +345,10 @@ extension TermsOfUseViewController {
                 }
             }
             
-            joinButton.snp.makeConstraints {
+            acceptButton.snp.makeConstraints {
                 $0.leading.equalToSuperview().offset(.spacing16)
                 $0.trailing.equalToSuperview().inset(.spacing16)
-                $0.height.equalTo(Constants.Size.joinButtonHeight)
+                $0.height.equalTo(Constants.Size.acceptButtonHeight)
                 $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
             }
             


### PR DESCRIPTION
### 이슈
#57 

### 수정사항
* 유저 토큰 관리용 `UserAuthService` 구현
* 저장된 토큰 여/부에 따른 화면 전환 플로우 수정
* 로그인시 플로우 수정 (로그인 버튼 -> 토큰 요청 -> 약관 확인 -> 로그인 API 호출 -> 토큰 저장 -> 화면 홈으로 이동)
(일단 빠른 배포를 위해... **Interactor**에 좀... 🥺)

### (기타, 스크린샷, 트러블슈팅)
https://github.com/YAPP-Github/PyonsnalColor-iOS/assets/22838614/52d1df66-a43b-43e4-8821-b01c8054f7c8