### PR TITLE
페이지 뷰컨의 화면 스와이프시 상품이 보여지지 않는 버그 수정

### DIFF
--- a/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeInteractor.swift
@@ -33,7 +33,7 @@ final class EventHomeInteractor:
     
     private var dependency: EventHomeDependency?
     private var cancellable = Set<AnyCancellable>()
-    private let initialPage: Int = 1
+    private let initialPage: Int = 0
     private let initialCount: Int = 20
     private let productPerPage: Int = 10
     private var currentPage: Int = 1
@@ -98,7 +98,16 @@ final class EventHomeInteractor:
     }
     
     func didChangeStore(to store: ConvenienceStore) {
-        requestProducts(pageNumber: initialPage, pageSize: initialCount, store: store)
-        requestEventBanners(store: store)
+        requestInitialProducts(store: store)
+        
+        if store != .all {
+            requestEventBanners(store: store)
+        }
+    }
+    
+    func didScrollToNextPage(store: ConvenienceStore) {
+        if let lastPage = storeLastPages[store] {
+            requestProducts(pageNumber: lastPage + 1, store: store)
+        }
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomePageViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomePageViewController.swift
@@ -17,11 +17,10 @@ protocol EventHomePageViewControllerDelegate: AnyObject {
 final class EventHomePageViewController: UIPageViewController {
     
     // MARK: - Private property
-    private var pageViewControllers = [EventHomeTabViewController]()
+    private(set) var pageViewControllers = [EventHomeTabViewController]()
     private var currentIndex: Int = 0
     private var tabCount: Int = 5 // 임시
     
-    var currentViewController: EventHomeTabViewController?
     weak var pageDelegate: EventHomePageViewControllerDelegate?
     weak var scrollDelegate: ScrollDelegate?
 
@@ -44,7 +43,6 @@ final class EventHomePageViewController: UIPageViewController {
         self.delegate = self
         self.dataSource = self
         if let firstViewController = pageViewControllers.first {
-            currentViewController = firstViewController
             setViewControllers([firstViewController],
                                direction: .forward,
                                animated: true)
@@ -53,7 +51,6 @@ final class EventHomePageViewController: UIPageViewController {
     
     func updatePage(_ index: Int) {
         let viewController = pageViewControllers[index]
-
         let direction: UIPageViewController.NavigationDirection = currentIndex <= index ? .forward : .reverse
         currentIndex = index
         
@@ -77,6 +74,7 @@ extension EventHomePageViewController: UIPageViewControllerDelegate, UIPageViewC
             return
         }
         
+        currentIndex = index
         pageDelegate?.updateSelectedStoreCell(index: index)
     }
     
@@ -87,9 +85,7 @@ extension EventHomePageViewController: UIPageViewControllerDelegate, UIPageViewC
         if let viewController = viewController as? EventHomeTabViewController {
             guard let index = pageViewControllers.firstIndex(of: viewController) else { return nil }
             let beforeIndex = index - 1
-            currentIndex = beforeIndex
             if beforeIndex >= 0, beforeIndex < pageViewControllers.count {
-                currentViewController = pageViewControllers[beforeIndex]
                 return pageViewControllers[beforeIndex]
             }
         }
@@ -103,9 +99,7 @@ extension EventHomePageViewController: UIPageViewControllerDelegate, UIPageViewC
         if let viewController =  viewController as? EventHomeTabViewController {
             guard let index = pageViewControllers.firstIndex(of: viewController) else { return nil }
             let afterIndex = index + 1
-            currentIndex = afterIndex
             if afterIndex >= 0, afterIndex < pageViewControllers.count {
-                currentViewController = pageViewControllers[afterIndex]
                 return pageViewControllers[afterIndex]
             }
         }
@@ -142,7 +136,7 @@ extension EventHomePageViewController: EventHomeTabViewControllerDelegate {
 
 extension EventHomePageViewController: ProductListDelegate {
     func didLoadPageList(store: ConvenienceStore) {
-        pageDelegate?.didChangeStore(to: ConvenienceStore.allCases[currentIndex])
+        pageDelegate?.didChangeStore(to: store)
     }
     
     func refreshByPull() {

--- a/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeTabViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeTabViewController.swift
@@ -53,7 +53,7 @@ final class EventHomeTabViewController: UIViewController {
     private let refreshControl = UIRefreshControl()
     private let dummyImage = UIImage(systemName: "note")
     private var lastContentOffSetY: CGFloat = 0
-    private let convenienceStore: ConvenienceStore
+    let convenienceStore: ConvenienceStore
     
     init(convenienceStore: ConvenienceStore) {
         self.convenienceStore = convenienceStore

--- a/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeViewController.swift
@@ -128,14 +128,24 @@ final class EventHomeViewController: UIViewController,
         )
     }
     
-    func updateProducts(with products: [EventProductEntity]) {
-        let productsViewController = viewHolder.pageViewController.currentViewController
-        productsViewController?.applyEventProductsSnapshot(with: products)
+    func updateProducts(with products: [EventProductEntity], at store: ConvenienceStore) {
+        if let storeIndex = ConvenienceStore.allCases.firstIndex(of: store) {
+            let tabViewController = viewHolder.pageViewController.pageViewControllers[storeIndex]
+            
+            tabViewController.applyEventProductsSnapshot(with: products)
+        }
     }
     
-    func updateBanners(with banners: [EventBannerEntity]) {
-        let productsViewController = viewHolder.pageViewController.currentViewController
-        productsViewController?.applyEventBannerSnapshot(with: banners)
+    func updateBanners(with banners: [EventBannerEntity], at store: ConvenienceStore) {
+        if let storeIndex = ConvenienceStore.allCases.firstIndex(of: store) {
+            let tabViewController = viewHolder.pageViewController.pageViewControllers[storeIndex]
+            
+            tabViewController.applyEventBannerSnapshot(with: banners)
+        }
+    }
+    
+    func didFinishPaging() {
+        isPaging = false
     }
     
 }
@@ -255,7 +265,6 @@ extension EventHomeViewController: EventHomePageViewControllerDelegate {
     func updateSelectedStoreCell(index: Int) {
         let indexPath = IndexPath(row: index, section: 0)
         setSelectedConvenienceStoreCell(with: indexPath)
-        didChangeStore(to: ConvenienceStore.allCases[index])
     }
     
     func didTapEventBannerCell(with imageUrl: String) {

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeInteractor.swift
@@ -16,8 +16,7 @@ protocol ProductHomeRouting: ViewableRouting {
 protocol ProductHomePresentable: Presentable {
     var listener: ProductHomePresentableListener? { get set }
     
-    func updateProducts(with products: [BrandProductEntity])
-    func appendProducts(with products: [ConvenienceStore: [BrandProductEntity]])
+    func updateProducts(with products: [ConvenienceStore: [BrandProductEntity]])
     func didFinishPaging()
 }
 
@@ -40,7 +39,7 @@ final class ProductHomeInteractor:
     private var storeLastPages: [ConvenienceStore: Int] = [:]
     private var brandProducts: [ConvenienceStore: [BrandProductEntity]] = [:] {
         didSet {
-            presenter.appendProducts(with: brandProducts)
+            presenter.updateProducts(with: brandProducts)
             presenter.didFinishPaging()
         }
     }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeInteractor.swift
@@ -17,6 +17,7 @@ protocol ProductHomePresentable: Presentable {
     var listener: ProductHomePresentableListener? { get set }
     
     func updateProducts(with products: [ConvenienceStore: [BrandProductEntity]])
+    func updateProducts(with products: [BrandProductEntity], at store: ConvenienceStore)
     func didFinishPaging()
 }
 
@@ -37,12 +38,7 @@ final class ProductHomeInteractor:
     private let initialCount: Int = 20
     private let productPerPage: Int = 20
     private var storeLastPages: [ConvenienceStore: Int] = [:]
-    private var brandProducts: [ConvenienceStore: [BrandProductEntity]] = [:] {
-        didSet {
-            presenter.updateProducts(with: brandProducts)
-            presenter.didFinishPaging()
-        }
-    }
+    private var brandProducts: [ConvenienceStore: [BrandProductEntity]] = [:]
 
     init(
         presenter: ProductHomePresentable,
@@ -73,6 +69,9 @@ final class ProductHomeInteractor:
         ).sink { [weak self] response in
             if let productPage = response.value {
                 self?.brandProducts[store] = productPage.content
+                if let products = self?.brandProducts[store] {
+                    self?.presenter.updateProducts(with: products, at: store)
+                }
             } else if response.error != nil {
                 // TODO: Error Handling
             }
@@ -88,6 +87,10 @@ final class ProductHomeInteractor:
         ).sink { [weak self] response in
             if let productPage = response.value {
                 self?.brandProducts[store]? += productPage.content
+                if let products = self?.brandProducts[store] {
+                    self?.presenter.updateProducts(with: products, at: store)
+                    self?.presenter.didFinishPaging()
+                }
             }
         }.store(in: &cancellable)
     }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeViewController.swift
@@ -118,6 +118,14 @@ final class ProductHomeViewController:
         }
     }
     
+    func updateProducts(with products: [BrandProductEntity], at store: ConvenienceStore) {
+        if let storeIndex = ConvenienceStore.allCases.firstIndex(of: store) {
+            let pageViewController = viewHolder.productHomePageViewController
+            let viewController = pageViewController.productListViewControllers[storeIndex]
+            viewController.applySnapshot(with: products)
+        }
+    }
+    
     func didFinishPaging() {
         isPaging = false
     }
@@ -189,7 +197,7 @@ extension ProductHomeViewController: UIScrollViewDelegate {
             collectionView.contentOffset.y = innerScrollLastOffsetY
         }
         
-        let paginationHeight = (collectionView.contentSize.height - collectionView.bounds.height) * 0.9
+        let paginationHeight = abs(collectionView.contentSize.height - collectionView.bounds.height) * 0.9
 
         if innerScroll && !isPaging && paginationHeight <= collectionView.contentOffset.y {
             isPaging = true

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/Views/ProductHomePageViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/Views/ProductHomePageViewController.swift
@@ -17,7 +17,6 @@ final class ProductHomePageViewController: UIPageViewController {
     //MARK: - Property
     weak var pagingDelegate: ProductHomePageViewControllerDelegate?
     var productListViewControllers: [ProductListViewController] = []
-    var currentViewController: ProductListViewController?
     
     //MARK: - Life Cycle
     override func viewDidLoad() {
@@ -42,13 +41,12 @@ final class ProductHomePageViewController: UIPageViewController {
         
         if let firstViewController = productListViewControllers.first {
             setViewControllers([firstViewController], direction: .forward, animated: true)
-            currentViewController = firstViewController
         }
     }
     
     func updatePage(to page: Int) {
-        guard let currentViewController,
-              let currentIndex = productListViewControllers.firstIndex(of: currentViewController)
+        guard let viewController = viewControllers?.first as? ProductListViewController,
+              let currentIndex = productListViewControllers.firstIndex(of: viewController)
         else {
             return
         }
@@ -61,7 +59,6 @@ final class ProductHomePageViewController: UIPageViewController {
             animated: true,
             completion: nil
         )
-        self.currentViewController = productListViewControllers[page]
     }
 }
 
@@ -113,7 +110,6 @@ extension ProductHomePageViewController: UIPageViewControllerDelegate {
             return
         }
         
-        currentViewController = viewController
         pagingDelegate?.didFinishPageTransition(index: index)
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/Views/ProductListViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/Views/ProductListViewController.swift
@@ -30,7 +30,7 @@ final class ProductListViewController: UIViewController {
     private var dataSource: DataSource?
     weak var delegate: ProductListDelegate?
     private let refreshControl: UIRefreshControl = .init()
-    private let convenienceStore: ConvenienceStore
+    let convenienceStore: ConvenienceStore
     
     //MARK: - View Component
     lazy var productCollectionView: UICollectionView = {


### PR DESCRIPTION
### 이슈
#64

### 수정사항
두가지 문제에 대한 수정사항이 있었습니다!

#### 1. 페이지 뷰컨의 화면 스와이프 시 상품이 늦게 로드되거나 보여지지 않는 문제
- 상품을 요청하는 뷰컨(편의점 정보 + 상품정보들) & 현재 보여지는 뷰컨이 달라 싱크가 맞지 않는 문제가 있었습니다.
  - 페이지뷰컨에서 `currentViewController`를 프로퍼티로 생성하고 변경하고있었는데 이를 삭제하고 페이지뷰컨 자체 프로퍼티를 이용해 접근하도록 수정해서 상품 로드 뷰컨과 현재 뷰컨이 같도록 수정하였습니다.
  - `PageViewController`의 `delegate`메서드는 여러번 호출되어서 해당 메서드 내에서는 어떤 값을 지정하지 않도록 수정하였습니다.
  (ex. `currentIndex / currentViewController` )
  - 페이지뷰컨의 하위 뷰컨들에게 각각 편의점 정보를 프로퍼티로 지정하여 상품정보 호출 시 해당 편의점 정보를 매개변수로 전달할 수 있도록 수정하였습니다.
 
#### 2. 편의점 종류 컬렉션뷰를 통해 화면 전환 후 스크롤 시작시, 이전 스크롤 오프셋으로 화면이 전환되는 문제

### 스크린샷
|<img src="https://github.com/YAPP-Github/PyonsnalColor-iOS/assets/71054048/d2909b22-1d0f-4a20-afd0-e376af89d74d" width=250>|<img src="https://github.com/YAPP-Github/PyonsnalColor-iOS/assets/71054048/c10c5b7c-8ecc-4bfa-b386-cd45fa5d1126" width=250>|
|:-:|:-:|
|이슈 - 화면이 늦게 로드되거나 보이지 않음|수정 후|

|<img src="https://github.com/YAPP-Github/PyonsnalColor-iOS/assets/71054048/618f249e-5e42-4bfd-ba05-2829f435531c" width=250>|<img src="https://github.com/YAPP-Github/PyonsnalColor-iOS/assets/71054048/52b6b2fd-b664-4a86-ab34-035ed2dba8a7" width=250>|
|:-:|:-:|
|이슈 - 화면 전환 후 스크롤 시작시 <br>이전 화면으로 변경|수정 후|

