### PR TITLE
Fix: 스크롤 후 update()시 타이머가 연속 설정되어 스크롤이 빨라지는 이슈 수정

### DIFF
--- a/Pyonsnal-Color/Pyonsnal-Color/EventHome/Views/Cell/EventBannerCell.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/EventHome/Views/Cell/EventBannerCell.swift
@@ -122,6 +122,7 @@ final class EventBannerCell: UICollectionViewCell {
 extension EventBannerCell {
     
     private func setTimer() {
+        if timer != nil { stopTimer() }
         DispatchQueue.main.async { [weak self] in
             self?.timer = Timer.scheduledTimer(withTimeInterval: Constants.timeSecond,
                                          repeats: true) { [weak self] _ in


### PR DESCRIPTION
### 수정사항
이벤트 배너 cell에서 스크롤시 update() 함수가 호출되는데 이때 timer 객체가 여러개 설정될때 스크롤이 빨라지는 이슈가 있어 
스크롤 객체가 있을때 invalide 처리 해주도록 코드를 추가하였습니다.

### 트러블슈팅
5초 이후 auto scroll이 되어야 하는데 연속으로 스크롤 되는 이슈

https://github.com/YAPP-Github/PyonsnalColor-iOS/assets/50979257/4ecbfc0d-a6a9-4329-a08f-0ad3455e63cb

수정 후

https://github.com/YAPP-Github/PyonsnalColor-iOS/assets/50979257/45c8ac8a-5406-40f2-b037-7fe7d79f6867

