### PR TITLE
상품 홈/행사 화면에서 탭을 눌러 상단으로 이동 중 화면이 하얘지는 버그 수정

### DIFF
--- a/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeViewController.swift
@@ -346,8 +346,14 @@ extension EventHomeViewController: UIScrollViewDelegate {
             //안쪽을 아래로 스크롤할때 바깥쪽 먼저 아래로 스크롤
             guard viewHolder.containerScrollView.contentOffset.y < outerScrollMaxOffset else { return }
   
-            let minOffsetY = min(viewHolder.containerScrollView.contentOffset.y + scrollView.contentOffset.y - innerScrollLastOffsetY, outerScrollMaxOffset)
-            viewHolder.containerScrollView.contentOffset.y = minOffsetY
+            let scrolledHeight = scrollView.contentOffset.y - innerScrollLastOffsetY
+            let minOffsetY = min(
+                viewHolder.containerScrollView.contentOffset.y + scrolledHeight,
+                outerScrollMaxOffset
+            )
+            let offsetY = max(minOffsetY, 0)
+            
+            viewHolder.containerScrollView.contentOffset.y = offsetY
             collectionView.contentOffset.y = innerScrollLastOffsetY
         }
     }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeViewController.swift
@@ -212,8 +212,9 @@ extension ProductHomeViewController: UIScrollViewDelegate {
                 viewHolder.containerScrollView.contentOffset.y + scrolledHeight,
                 outerScrollMaxOffset
             )
+            let offsetY = max(minOffsetY, 0)
             
-            viewHolder.containerScrollView.contentOffset.y = minOffsetY
+            viewHolder.containerScrollView.contentOffset.y = offsetY
             collectionView.contentOffset.y = innerScrollLastOffsetY
         }
     }


### PR DESCRIPTION
### 이슈
#84 

### 수정사항
- 간헐적으로 탭을 눌러 화면 상단으로 이동 시 화면이 하얘지는 버그가 있어서 수정하였습니다. (오토레이아웃 깨짐 문제)
```swift
func scrollViewDidScroll(_ scrollView: UIScrollView) {
    ...
    if innerScroll && downScroll {
        ...
        let scrolledHeight = scrollView.contentOffset.y - innerScrollLastOffsetY
        let minOffsetY = min(
            viewHolder.containerScrollView.contentOffset.y + scrolledHeight,
            outerScrollMaxOffset
        )
        let offsetY = max(minOffsetY, 0)
        
        //기존 코드(삭제됨)
        viewHolder.containerScrollView.contentOffset.y = minOffsetY
        //수정된 코드
        viewHolder.containerScrollView.contentOffset.y = offsetY
        ...
    }
}
```
- 탭을 눌러 상단으로 이동 중 위 코드부분이 실행되고, 그 중 minOffset값이 음수로 들어오고 오토레이아웃이 깨지는 문제가 있었습니다.
- `contentOffset`에 값을 지정하기 전에 음수 값이 전달되는걸 방지하기 위해 0값과 비교하는 로직 (`offset`) 을 추가하였습니다.
