### PR TITLE
Log 파일 생성

### DIFF
--- a/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
+++ b/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
@@ -158,6 +158,8 @@
 		F0C582C22A55E83400DAD387 /* TermsOfUseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C582BE2A55E83400DAD387 /* TermsOfUseViewController.swift */; };
 		F0C582C32A55E83400DAD387 /* TermsOfUseBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C582BF2A55E83400DAD387 /* TermsOfUseBuilder.swift */; };
 		F0C582C42A55E83400DAD387 /* TermsOfUseInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C582C02A55E83400DAD387 /* TermsOfUseInteractor.swift */; };
+		F0C6985F2A6ABDDD0019C677 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C6985E2A6ABDDD0019C677 /* Log.swift */; };
+		F0C698632A6ABE5B0019C677 /* OSLog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F0C698612A6ABE2D0019C677 /* OSLog.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		F0C87AEE2A51D54B00EA4C76 /* PyonsnalColorClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C87AED2A51D54B00EA4C76 /* PyonsnalColorClient.swift */; };
 		F0C87AF02A51D74900EA4C76 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C87AEF2A51D74900EA4C76 /* NetworkError.swift */; };
 		F0C87AF32A51DFC300EA4C76 /* ErrorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C87AF22A51DFC300EA4C76 /* ErrorResponse.swift */; };
@@ -324,6 +326,8 @@
 		F0C582BE2A55E83400DAD387 /* TermsOfUseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfUseViewController.swift; sourceTree = "<group>"; };
 		F0C582BF2A55E83400DAD387 /* TermsOfUseBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfUseBuilder.swift; sourceTree = "<group>"; };
 		F0C582C02A55E83400DAD387 /* TermsOfUseInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfUseInteractor.swift; sourceTree = "<group>"; };
+		F0C6985E2A6ABDDD0019C677 /* Log.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
+		F0C698612A6ABE2D0019C677 /* OSLog.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OSLog.framework; path = System/Library/Frameworks/OSLog.framework; sourceTree = SDKROOT; };
 		F0C87AED2A51D54B00EA4C76 /* PyonsnalColorClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PyonsnalColorClient.swift; sourceTree = "<group>"; };
 		F0C87AEF2A51D74900EA4C76 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		F0C87AF22A51DFC300EA4C76 /* ErrorResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorResponse.swift; sourceTree = "<group>"; };
@@ -351,6 +355,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F0C698632A6ABE5B0019C677 /* OSLog.framework in Frameworks */,
 				BA3EB2FE2A6074090091C8DB /* FirebaseAnalyticsSwift in Frameworks */,
 				BA3EB3002A6074090091C8DB /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */,
 				B2A57BEF2A2C7596005DB83E /* KakaoSDKUser in Frameworks */,
@@ -685,6 +690,7 @@
 				BA9E234F2A234B4D00A539D5 /* .swiftlint.yml */,
 				BA9E23392A21EF3000A539D5 /* Pyonsnal-Color */,
 				BA9E23382A21EF3000A539D5 /* Products */,
+				F0C698602A6ABE2C0019C677 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -729,6 +735,7 @@
 		BAEA1BFB2A3477A80028A90A /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				F0C6985D2A6ABDCB0019C677 /* Log */,
 				F097EF232A5605CD00A7FB9C /* Button */,
 				BA0D77F32A56C12C0041C2D5 /* Tag */,
 				B24F1D492A4BB81000AA03DC /* NavigationBar */,
@@ -882,6 +889,22 @@
 				F0C582C02A55E83400DAD387 /* TermsOfUseInteractor.swift */,
 			);
 			path = TermsOfUse;
+			sourceTree = "<group>";
+		};
+		F0C6985D2A6ABDCB0019C677 /* Log */ = {
+			isa = PBXGroup;
+			children = (
+				F0C6985E2A6ABDDD0019C677 /* Log.swift */,
+			);
+			path = Log;
+			sourceTree = "<group>";
+		};
+		F0C698602A6ABE2C0019C677 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				F0C698612A6ABE2D0019C677 /* OSLog.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		F0D6FFA72A39F57600C55E27 /* Cell */ = {
@@ -1066,6 +1089,7 @@
 				F049E8C52A51CAE700E61199 /* ImageAssetKind+StoreTag.swift in Sources */,
 				F097EF372A571DD300A7FB9C /* CommonWebInteractor.swift in Sources */,
 				F0EE10B02A4B4DF600B8DF4F /* ItemIdentifier.swift in Sources */,
+				F0C6985F2A6ABDDD0019C677 /* Log.swift in Sources */,
 				BA87E3CC2A45C5A1000A9DEC /* ProductDetailRouter.swift in Sources */,
 				B282050C2A34700300F9242F /* EventHomeBuilder.swift in Sources */,
 				BA437F182A235F5100C5DFA8 /* LoggedOutBuilder.swift in Sources */,

--- a/Pyonsnal-Color/Pyonsnal-Color/Common/Log/Log.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Common/Log/Log.swift
@@ -133,8 +133,7 @@ class Log {
         let logger  = Logger(subsystem: Log.subsystem, category: logType.category)
         
         let fileURL = URL(fileURLWithPath: fileName, isDirectory: false)
-        let pathExtension = fileURL.pathExtension
-        let fileName = "\(fileURL.lastPathComponent).\(pathExtension)"
+        let fileName = fileURL.lastPathComponent
         
         let message = """
         [\(logType.category) - \(fileName)]

--- a/Pyonsnal-Color/Pyonsnal-Color/Common/Log/Log.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Common/Log/Log.swift
@@ -1,0 +1,160 @@
+//
+//  Log.swift
+//  Pyonsnal-Color
+//
+//  Created by 조소정 on 2023/07/21.
+//
+
+import Foundation
+import os.log
+
+enum LogType: String {
+    /// 디버깅 관련 정보
+    case debug
+    /// 도움이 되지만, 필수적이지 않은 정보
+    case info
+    /// 네트워크 관련 정보
+    case network
+    /// 에러 정보
+    case error
+    /// 코드 결함이나 버그 정보
+    case fault
+    
+    var osLogType: OSLogType {
+        switch self {
+        case .debug:
+            return .debug
+        case .info:
+            return .info
+        case .network:
+            return .debug
+        case .error:
+            return .error
+        case .fault:
+            return .fault
+        }
+    }
+    
+    var category: String {
+        switch self {
+        case .debug:
+            return "🛠️ Debug"
+        case .info:
+            return "ℹ️ Info"
+        case .network:
+            return "🕸️ Network"
+        case .error:
+            return "⚠️ Error"
+        case .fault:
+            return "🚨 Fault"
+        }
+    }
+}
+
+class Log {
+    private static let subsystem = Bundle.main.bundleIdentifier ?? ""
+    
+    /// 디버깅 관련 정보
+    static func d(
+        message: String,
+        fileName: String = #file,
+        functionName: String = #function
+    ) {
+        self.log(
+            message: message,
+            fileName: fileName,
+            functionName: functionName,
+            logType: .debug
+        )
+    }
+    
+    /// 도움이 되지만, 필수적이지 않은 정보
+    static func i(
+        message: String,
+        fileName: String = #file,
+        functionName: String = #function
+    ) {
+        self.log(
+            message: message,
+            fileName: fileName,
+            functionName: functionName,
+            logType: .info
+        )
+    }
+    
+    /// 네트워크 관련 정보
+    static func n(
+        message: String,
+        fileName: String = #file,
+        functionName: String = #function
+    ) {
+        self.log(
+            message: message,
+            fileName: fileName,
+            functionName: functionName,
+            logType: .debug
+        )
+    }
+    
+    /// 에러 정보
+    static func e(
+        message: String,
+        fileName: String = #file,
+        functionName: String = #function
+    ) {
+        self.log(
+            message: message,
+            fileName: fileName,
+            functionName: functionName,
+            logType: .error
+        )
+    }
+    
+    /// 코드 결함이나 버그 정보
+    static func f(
+        message: String,
+        fileName: String = #file,
+        functionName: String = #function
+    ) {
+        self.log(
+            message: message,
+            fileName: fileName,
+            functionName: functionName,
+            logType: .fault
+        )
+    }
+    
+    private static func log(
+        message: String,
+        fileName: String,
+        functionName: String,
+        logType: LogType
+    ) {
+        let logger  = Logger(subsystem: Log.subsystem, category: logType.category)
+        
+        let fileURL = URL(fileURLWithPath: fileName, isDirectory: false)
+        let pathExtension = fileURL.pathExtension
+        let fileName = "\(fileURL.lastPathComponent).\(pathExtension)"
+        
+        let message = """
+        [\(fileName)]
+        \(functionName)
+        \(message)
+        """
+        
+        switch logType {
+        case .debug:
+            logger.debug("\(message, privacy: .public)")
+        case .info:
+            logger.info("\(message, privacy: .public)")
+        case .network:
+            logger.debug("\(message, privacy: .public)")
+        case .error:
+            logger.error("\(message, privacy: .public)")
+        case .fault:
+            logger.fault("\(message, privacy: .public)")
+        }
+        
+    }
+    
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/Common/Log/Log.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Common/Log/Log.swift
@@ -92,7 +92,7 @@ class Log {
             message: message,
             fileName: fileName,
             functionName: functionName,
-            logType: .debug
+            logType: .network
         )
     }
     
@@ -137,7 +137,7 @@ class Log {
         let fileName = "\(fileURL.lastPathComponent).\(pathExtension)"
         
         let message = """
-        [\(fileName)]
+        [\(logType.category) - \(fileName)]
         \(functionName)
         \(message)
         """


### PR DESCRIPTION
### 이슈
#92 

### 수정사항
로깅을 위한 Log 파일을 생성하였습니다. 
print()는 메인쓰레드에서 동작하기 때문에 앱 성능에 좋지 않으며 OSLog 사용을 권장한다고 하여 OSLog를 사용하였습니다.
사용시에는 아래와 같이 사용하고
```swift
        Log.d(message: "debug")
        Log.e(message: "error")
        Log.n(message: "network")
        Log.f(message: "fault")
        Log.i(message: "info")
``` 
xcode 콘솔창에는 아래와 같이 출력됩니다 (이모지는 임의로 ,,,, 🤔 다른 더 적합한 이모지 있으면 알려주세여 !!)
참고로, xcode 15부터 요렇게 색깔로 구분이 가능해지고
<img width="704" alt="image" src="https://github.com/YAPP-Github/PyonsnalColor-iOS/assets/50979257/679eb998-7bef-4d2c-9ab5-b421c5f1ebe4">

로그 타입에 대해 필터링이 가능해진다고 합니다 !
<img width="758" alt="image" src="https://github.com/YAPP-Github/PyonsnalColor-iOS/assets/50979257/aaa51d93-dda3-4899-8a3b-82c01ef07135">


또한 콘솔 앱에서는 빌드가 되어 있는 상태에서 
하위 시스템에 bundle identifier로 검색시  error와 fault 타입에 대해 로깅 할 수 있습니다.
<img width="1340" alt="image" src="https://github.com/YAPP-Github/PyonsnalColor-iOS/assets/50979257/e136754d-9a79-42b5-b8c8-4b70ec355d97">

출력 메세지 형식에 대해 우선 아래와 같이 작성했는데 더 괜찮을까요 ??
```swift
        let message = """
        [\(logType.category) - \(fileName)]
        \(functionName)
        \(message)
        """
``` 
더 추가할 정보가 있다면 반영하겠습니다 ~!