### PR TITLE
필터 선택하는 바텀시트 구현

### DIFF
--- a/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
+++ b/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		B28A59272A6FCE9700431F39 /* ProductFilterSectionLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59262A6FCE9700431F39 /* ProductFilterSectionLayout.swift */; };
 		B28A592A2A6FCFED00431F39 /* SortFilterCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59292A6FCFED00431F39 /* SortFilterCell.swift */; };
 		B28A59302A739D3500431F39 /* EventFilterCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A592F2A739D3500431F39 /* EventFilterCell.swift */; };
+		B28A59322A73B08000431F39 /* CategoryFilterCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59312A73B08000431F39 /* CategoryFilterCell.swift */; };
 		B28A59132A6E98DB00431F39 /* CurationHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59122A6E98DB00431F39 /* CurationHeaderView.swift */; };
 		B28A59152A6E991100431F39 /* CurationFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59142A6E991100431F39 /* CurationFooterView.swift */; };
 		B28A59172A6E995500431F39 /* CurationEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59162A6E995500431F39 /* CurationEntity.swift */; };
@@ -270,6 +271,7 @@
 		B28A59262A6FCE9700431F39 /* ProductFilterSectionLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFilterSectionLayout.swift; sourceTree = "<group>"; };
 		B28A59292A6FCFED00431F39 /* SortFilterCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortFilterCell.swift; sourceTree = "<group>"; };
 		B28A592F2A739D3500431F39 /* EventFilterCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventFilterCell.swift; sourceTree = "<group>"; };
+		B28A59312A73B08000431F39 /* CategoryFilterCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryFilterCell.swift; sourceTree = "<group>"; };
 		B28A59122A6E98DB00431F39 /* CurationHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationHeaderView.swift; sourceTree = "<group>"; };
 		B28A59142A6E991100431F39 /* CurationFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationFooterView.swift; sourceTree = "<group>"; };
 		B28A59162A6E995500431F39 /* CurationEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationEntity.swift; sourceTree = "<group>"; };
@@ -600,6 +602,7 @@
 			children = (
 				B28A59292A6FCFED00431F39 /* SortFilterCell.swift */,
 				B28A592F2A739D3500431F39 /* EventFilterCell.swift */,
+				B28A59312A73B08000431F39 /* CategoryFilterCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -1412,6 +1415,7 @@
 				F02C8DA72A2E149700593A2D /* AppleLoginService.swift in Sources */,
 				F0C698652A6BA9B00019C677 /* CategoryFilterCell.swift in Sources */,
 				B24259032A590ECA006C5223 /* ConvenienceStore.swift in Sources */,
+				B28A59322A73B08000431F39 /* CategoryFilterCell.swift in Sources */,
 				BA00B7362A46B83A00BB3795 /* CGFloat+.swift in Sources */,
 				B24CAAE62A55AC35005BE499 /* NotificationListRouter.swift in Sources */,
 				B24259122A594AB7006C5223 /* ProductAPI.swift in Sources */,

--- a/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
+++ b/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		B28A59232A6FB2B200431F39 /* ProductFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A591F2A6FB2B200431F39 /* ProductFilterViewController.swift */; };
 		B28A59242A6FB2B200431F39 /* ProductFilterBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59202A6FB2B200431F39 /* ProductFilterBuilder.swift */; };
 		B28A59252A6FB2B200431F39 /* ProductFilterInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59212A6FB2B200431F39 /* ProductFilterInteractor.swift */; };
+		B28A59272A6FCE9700431F39 /* ProductFilterSectionLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59262A6FCE9700431F39 /* ProductFilterSectionLayout.swift */; };
 		B28A59132A6E98DB00431F39 /* CurationHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59122A6E98DB00431F39 /* CurationHeaderView.swift */; };
 		B28A59152A6E991100431F39 /* CurationFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59142A6E991100431F39 /* CurationFooterView.swift */; };
 		B28A59172A6E995500431F39 /* CurationEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59162A6E995500431F39 /* CurationEntity.swift */; };
@@ -264,6 +265,7 @@
 		B28A591F2A6FB2B200431F39 /* ProductFilterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFilterViewController.swift; sourceTree = "<group>"; };
 		B28A59202A6FB2B200431F39 /* ProductFilterBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFilterBuilder.swift; sourceTree = "<group>"; };
 		B28A59212A6FB2B200431F39 /* ProductFilterInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFilterInteractor.swift; sourceTree = "<group>"; };
+		B28A59262A6FCE9700431F39 /* ProductFilterSectionLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFilterSectionLayout.swift; sourceTree = "<group>"; };
 		B28A59122A6E98DB00431F39 /* CurationHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationHeaderView.swift; sourceTree = "<group>"; };
 		B28A59142A6E991100431F39 /* CurationFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationFooterView.swift; sourceTree = "<group>"; };
 		B28A59162A6E995500431F39 /* CurationEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationEntity.swift; sourceTree = "<group>"; };
@@ -567,6 +569,7 @@
 				B28A591F2A6FB2B200431F39 /* ProductFilterViewController.swift */,
 				B28A59202A6FB2B200431F39 /* ProductFilterBuilder.swift */,
 				B28A59212A6FB2B200431F39 /* ProductFilterInteractor.swift */,
+				B28A59262A6FCE9700431F39 /* ProductFilterSectionLayout.swift */,
 			);
 			path = ProductFilter;
 		B28A59112A6E98C000431F39 /* ReusableView */ = {
@@ -1310,6 +1313,7 @@
 				B24F1D4B2A4BB82D00AA03DC /* TitleNavigationView.swift in Sources */,
 				F00022462A5280FC00FFB4A4 /* NetworkRequestBuilder.swift in Sources */,
 				F00352242A62BD9F00A66FF9 /* UserLoginStatusEntity.swift in Sources */,
+				B28A59272A6FCE9700431F39 /* ProductFilterSectionLayout.swift in Sources */,
 				B242590E2A5947E7006C5223 /* PageableEntity.swift in Sources */,
 				F082381F2A49C0C2001C2ABE /* ClassNameRenderable.swift in Sources */,
 				BAEA1BF82A344D480028A90A /* LoggedOutViewController+ViewHolder.swift in Sources */,

--- a/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
+++ b/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
@@ -53,19 +53,19 @@
 		B28205132A34702B00F9242F /* ProductHomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B282050F2A34702B00F9242F /* ProductHomeViewController.swift */; };
 		B28205142A34702B00F9242F /* ProductHomeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28205102A34702B00F9242F /* ProductHomeBuilder.swift */; };
 		B28205152A34702B00F9242F /* ProductHomeInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28205112A34702B00F9242F /* ProductHomeInteractor.swift */; };
+		B28A59132A6E98DB00431F39 /* CurationHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59122A6E98DB00431F39 /* CurationHeaderView.swift */; };
+		B28A59152A6E991100431F39 /* CurationFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59142A6E991100431F39 /* CurationFooterView.swift */; };
+		B28A59172A6E995500431F39 /* CurationEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59162A6E995500431F39 /* CurationEntity.swift */; };
+		B28A591B2A6E9F3D00431F39 /* CurationImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A591A2A6E9F3D00431F39 /* CurationImageCell.swift */; };
 		B28A59222A6FB2B200431F39 /* ProductFilterRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A591E2A6FB2B200431F39 /* ProductFilterRouter.swift */; };
 		B28A59232A6FB2B200431F39 /* ProductFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A591F2A6FB2B200431F39 /* ProductFilterViewController.swift */; };
 		B28A59242A6FB2B200431F39 /* ProductFilterBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59202A6FB2B200431F39 /* ProductFilterBuilder.swift */; };
 		B28A59252A6FB2B200431F39 /* ProductFilterInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59212A6FB2B200431F39 /* ProductFilterInteractor.swift */; };
 		B28A59272A6FCE9700431F39 /* ProductFilterSectionLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59262A6FCE9700431F39 /* ProductFilterSectionLayout.swift */; };
 		B28A592A2A6FCFED00431F39 /* SortFilterCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59292A6FCFED00431F39 /* SortFilterCell.swift */; };
-		B28A59302A739D3500431F39 /* EventFilterCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A592F2A739D3500431F39 /* EventFilterCell.swift */; };
-		B28A59322A73B08000431F39 /* CategoryFilterCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59312A73B08000431F39 /* CategoryFilterCell.swift */; };
-		B28A59132A6E98DB00431F39 /* CurationHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59122A6E98DB00431F39 /* CurationHeaderView.swift */; };
-		B28A59152A6E991100431F39 /* CurationFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59142A6E991100431F39 /* CurationFooterView.swift */; };
-		B28A59172A6E995500431F39 /* CurationEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59162A6E995500431F39 /* CurationEntity.swift */; };
-		B28A591B2A6E9F3D00431F39 /* CurationImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A591A2A6E9F3D00431F39 /* CurationImageCell.swift */; };
 		B28A592E2A726C6500431F39 /* CurationSectionLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A592D2A726C6500431F39 /* CurationSectionLayout.swift */; };
+		B28A59302A739D3500431F39 /* EventFilterCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A592F2A739D3500431F39 /* EventFilterCell.swift */; };
+		B28A59322A73B08000431F39 /* RecommendFilterCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59312A73B08000431F39 /* RecommendFilterCell.swift */; };
 		B2A529492A57F2220010656A /* LogoutPopupRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A529452A57F2220010656A /* LogoutPopupRouter.swift */; };
 		B2A5294A2A57F2220010656A /* LogoutPopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A529462A57F2220010656A /* LogoutPopupViewController.swift */; };
 		B2A5294B2A57F2220010656A /* LogoutPopupBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A529472A57F2220010656A /* LogoutPopupBuilder.swift */; };
@@ -264,19 +264,19 @@
 		B282050F2A34702B00F9242F /* ProductHomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductHomeViewController.swift; sourceTree = "<group>"; };
 		B28205102A34702B00F9242F /* ProductHomeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductHomeBuilder.swift; sourceTree = "<group>"; };
 		B28205112A34702B00F9242F /* ProductHomeInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductHomeInteractor.swift; sourceTree = "<group>"; };
+		B28A59122A6E98DB00431F39 /* CurationHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationHeaderView.swift; sourceTree = "<group>"; };
+		B28A59142A6E991100431F39 /* CurationFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationFooterView.swift; sourceTree = "<group>"; };
+		B28A59162A6E995500431F39 /* CurationEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationEntity.swift; sourceTree = "<group>"; };
+		B28A591A2A6E9F3D00431F39 /* CurationImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationImageCell.swift; sourceTree = "<group>"; };
 		B28A591E2A6FB2B200431F39 /* ProductFilterRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFilterRouter.swift; sourceTree = "<group>"; };
 		B28A591F2A6FB2B200431F39 /* ProductFilterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFilterViewController.swift; sourceTree = "<group>"; };
 		B28A59202A6FB2B200431F39 /* ProductFilterBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFilterBuilder.swift; sourceTree = "<group>"; };
 		B28A59212A6FB2B200431F39 /* ProductFilterInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFilterInteractor.swift; sourceTree = "<group>"; };
 		B28A59262A6FCE9700431F39 /* ProductFilterSectionLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFilterSectionLayout.swift; sourceTree = "<group>"; };
 		B28A59292A6FCFED00431F39 /* SortFilterCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortFilterCell.swift; sourceTree = "<group>"; };
-		B28A592F2A739D3500431F39 /* EventFilterCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventFilterCell.swift; sourceTree = "<group>"; };
-		B28A59312A73B08000431F39 /* CategoryFilterCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryFilterCell.swift; sourceTree = "<group>"; };
-		B28A59122A6E98DB00431F39 /* CurationHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationHeaderView.swift; sourceTree = "<group>"; };
-		B28A59142A6E991100431F39 /* CurationFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationFooterView.swift; sourceTree = "<group>"; };
-		B28A59162A6E995500431F39 /* CurationEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationEntity.swift; sourceTree = "<group>"; };
-		B28A591A2A6E9F3D00431F39 /* CurationImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationImageCell.swift; sourceTree = "<group>"; };
 		B28A592D2A726C6500431F39 /* CurationSectionLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationSectionLayout.swift; sourceTree = "<group>"; };
+		B28A592F2A739D3500431F39 /* EventFilterCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventFilterCell.swift; sourceTree = "<group>"; };
+		B28A59312A73B08000431F39 /* RecommendFilterCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendFilterCell.swift; sourceTree = "<group>"; };
 		B2A529452A57F2220010656A /* LogoutPopupRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoutPopupRouter.swift; sourceTree = "<group>"; };
 		B2A529462A57F2220010656A /* LogoutPopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoutPopupViewController.swift; sourceTree = "<group>"; };
 		B2A529472A57F2220010656A /* LogoutPopupBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoutPopupBuilder.swift; sourceTree = "<group>"; };
@@ -568,17 +568,6 @@
 			path = ProfileHome;
 			sourceTree = "<group>";
 		};
-		B28A591D2A6FB29200431F39 /* ProductFilter */ = {
-			isa = PBXGroup;
-			children = (
-				B28A59282A6FCF9600431F39 /* Cell */,
-				B28A591E2A6FB2B200431F39 /* ProductFilterRouter.swift */,
-				B28A591F2A6FB2B200431F39 /* ProductFilterViewController.swift */,
-				B28A59202A6FB2B200431F39 /* ProductFilterBuilder.swift */,
-				B28A59212A6FB2B200431F39 /* ProductFilterInteractor.swift */,
-				B28A59262A6FCE9700431F39 /* ProductFilterSectionLayout.swift */,
-			);
-			path = ProductFilter;
 		B28A59112A6E98C000431F39 /* ReusableView */ = {
 			isa = PBXGroup;
 			children = (
@@ -597,12 +586,25 @@
 			path = Cell;
 			sourceTree = "<group>";
 		};
+		B28A591D2A6FB29200431F39 /* ProductFilter */ = {
+			isa = PBXGroup;
+			children = (
+				B28A59282A6FCF9600431F39 /* Cell */,
+				B28A591E2A6FB2B200431F39 /* ProductFilterRouter.swift */,
+				B28A591F2A6FB2B200431F39 /* ProductFilterViewController.swift */,
+				B28A59202A6FB2B200431F39 /* ProductFilterBuilder.swift */,
+				B28A59212A6FB2B200431F39 /* ProductFilterInteractor.swift */,
+				B28A59262A6FCE9700431F39 /* ProductFilterSectionLayout.swift */,
+			);
+			path = ProductFilter;
+			sourceTree = "<group>";
+		};
 		B28A59282A6FCF9600431F39 /* Cell */ = {
 			isa = PBXGroup;
 			children = (
 				B28A59292A6FCFED00431F39 /* SortFilterCell.swift */,
 				B28A592F2A739D3500431F39 /* EventFilterCell.swift */,
-				B28A59312A73B08000431F39 /* CategoryFilterCell.swift */,
+				B28A59312A73B08000431F39 /* RecommendFilterCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -1415,7 +1417,7 @@
 				F02C8DA72A2E149700593A2D /* AppleLoginService.swift in Sources */,
 				F0C698652A6BA9B00019C677 /* CategoryFilterCell.swift in Sources */,
 				B24259032A590ECA006C5223 /* ConvenienceStore.swift in Sources */,
-				B28A59322A73B08000431F39 /* CategoryFilterCell.swift in Sources */,
+				B28A59322A73B08000431F39 /* RecommendFilterCell.swift in Sources */,
 				BA00B7362A46B83A00BB3795 /* CGFloat+.swift in Sources */,
 				B24CAAE62A55AC35005BE499 /* NotificationListRouter.swift in Sources */,
 				B24259122A594AB7006C5223 /* ProductAPI.swift in Sources */,

--- a/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
+++ b/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
@@ -53,6 +53,10 @@
 		B28205132A34702B00F9242F /* ProductHomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B282050F2A34702B00F9242F /* ProductHomeViewController.swift */; };
 		B28205142A34702B00F9242F /* ProductHomeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28205102A34702B00F9242F /* ProductHomeBuilder.swift */; };
 		B28205152A34702B00F9242F /* ProductHomeInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28205112A34702B00F9242F /* ProductHomeInteractor.swift */; };
+		B28A59222A6FB2B200431F39 /* ProductFilterRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A591E2A6FB2B200431F39 /* ProductFilterRouter.swift */; };
+		B28A59232A6FB2B200431F39 /* ProductFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A591F2A6FB2B200431F39 /* ProductFilterViewController.swift */; };
+		B28A59242A6FB2B200431F39 /* ProductFilterBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59202A6FB2B200431F39 /* ProductFilterBuilder.swift */; };
+		B28A59252A6FB2B200431F39 /* ProductFilterInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59212A6FB2B200431F39 /* ProductFilterInteractor.swift */; };
 		B28A59132A6E98DB00431F39 /* CurationHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59122A6E98DB00431F39 /* CurationHeaderView.swift */; };
 		B28A59152A6E991100431F39 /* CurationFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59142A6E991100431F39 /* CurationFooterView.swift */; };
 		B28A59172A6E995500431F39 /* CurationEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59162A6E995500431F39 /* CurationEntity.swift */; };
@@ -256,6 +260,10 @@
 		B282050F2A34702B00F9242F /* ProductHomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductHomeViewController.swift; sourceTree = "<group>"; };
 		B28205102A34702B00F9242F /* ProductHomeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductHomeBuilder.swift; sourceTree = "<group>"; };
 		B28205112A34702B00F9242F /* ProductHomeInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductHomeInteractor.swift; sourceTree = "<group>"; };
+		B28A591E2A6FB2B200431F39 /* ProductFilterRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFilterRouter.swift; sourceTree = "<group>"; };
+		B28A591F2A6FB2B200431F39 /* ProductFilterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFilterViewController.swift; sourceTree = "<group>"; };
+		B28A59202A6FB2B200431F39 /* ProductFilterBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFilterBuilder.swift; sourceTree = "<group>"; };
+		B28A59212A6FB2B200431F39 /* ProductFilterInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFilterInteractor.swift; sourceTree = "<group>"; };
 		B28A59122A6E98DB00431F39 /* CurationHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationHeaderView.swift; sourceTree = "<group>"; };
 		B28A59142A6E991100431F39 /* CurationFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationFooterView.swift; sourceTree = "<group>"; };
 		B28A59162A6E995500431F39 /* CurationEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationEntity.swift; sourceTree = "<group>"; };
@@ -552,6 +560,15 @@
 			path = ProfileHome;
 			sourceTree = "<group>";
 		};
+		B28A591D2A6FB29200431F39 /* ProductFilter */ = {
+			isa = PBXGroup;
+			children = (
+				B28A591E2A6FB2B200431F39 /* ProductFilterRouter.swift */,
+				B28A591F2A6FB2B200431F39 /* ProductFilterViewController.swift */,
+				B28A59202A6FB2B200431F39 /* ProductFilterBuilder.swift */,
+				B28A59212A6FB2B200431F39 /* ProductFilterInteractor.swift */,
+			);
+			path = ProductFilter;
 		B28A59112A6E98C000431F39 /* ReusableView */ = {
 			isa = PBXGroup;
 			children = (
@@ -810,6 +827,7 @@
 		BA9E23392A21EF3000A539D5 /* Pyonsnal-Color */ = {
 			isa = PBXGroup;
 			children = (
+				B28A591D2A6FB29200431F39 /* ProductFilter */,
 				BA50FCFC2A680A8D00721782 /* ProductSearch */,
 				F097EF2F2A571DB000A7FB9C /* CommonWeb */,
 				F0C582BC2A55E81700DAD387 /* TermsOfUse */,
@@ -1273,6 +1291,7 @@
 				BA18075C2A2F189A00295398 /* UIButton+.swift in Sources */,
 				BA50FD042A680AA900721782 /* ProductSearchInteractor.swift in Sources */,
 				F0EE10A12A4B122A00B8DF4F /* UITableView+.swift in Sources */,
+				B28A59222A6FB2B200431F39 /* ProductFilterRouter.swift in Sources */,
 				B24CAAE22A55AC2B005BE499 /* NotificationListViewHolder.swift in Sources */,
 				B28205152A34702B00F9242F /* ProductHomeInteractor.swift in Sources */,
 				F0168D532A500AC900978ED9 /* EventDetailBuilder.swift in Sources */,
@@ -1325,6 +1344,7 @@
 				F0D8FEBE2A3EDB6B000B530A /* UIColor+.swift in Sources */,
 				B28204F32A345EB100F9242F /* RootComponent.swift in Sources */,
 				F0168D522A500AC900978ED9 /* EventDetailViewController.swift in Sources */,
+				B28A59252A6FB2B200431F39 /* ProductFilterInteractor.swift in Sources */,
 				F0DFBC942A595171003F7660 /* MemberAPI.swift in Sources */,
 				BA7B31842A72AA7900A117F3 /* ImageAssetKind+TabBar.swift in Sources */,
 				BA18075A2A2F170100295398 /* UIImageView+.swift in Sources */,
@@ -1356,6 +1376,7 @@
 				B24F1D312A431E1700AA03DC /* ConvenienceStoreCell.swift in Sources */,
 				BA4818CD2A59405300BF9CAD /* AuthAPIService.swift in Sources */,
 				F0C87AEE2A51D54B00EA4C76 /* PyonsnalColorClient.swift in Sources */,
+				B28A59232A6FB2B200431F39 /* ProductFilterViewController.swift in Sources */,
 				B2538B932A34551D00B7C3F0 /* LoggedInRouter.swift in Sources */,
 				BAB54A952A5949B700D45A80 /* ImageAssetKind+Splash.swift in Sources */,
 				BA87E3DE2A4629B5000A9DEC /* EventProductEntity.swift in Sources */,
@@ -1391,6 +1412,7 @@
 				F097EF2A2A5717B900A7FB9C /* SubTerms.swift in Sources */,
 				B27349E02A5AC7F900B97E59 /* EventBannerEntity.swift in Sources */,
 				F0D6FFAF2A39FFFA00C55E27 /* ProductCell.swift in Sources */,
+				B28A59242A6FB2B200431F39 /* ProductFilterBuilder.swift in Sources */,
 				F0DFBC982A5966CD003F7660 /* EmptyResponse.swift in Sources */,
 				BA00B7392A46B8BF00BB3795 /* Spacing.swift in Sources */,
 				BA00B73C2A46B98700BB3795 /* SnapKit+.swift in Sources */,

--- a/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
+++ b/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		B28A59252A6FB2B200431F39 /* ProductFilterInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59212A6FB2B200431F39 /* ProductFilterInteractor.swift */; };
 		B28A59272A6FCE9700431F39 /* ProductFilterSectionLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59262A6FCE9700431F39 /* ProductFilterSectionLayout.swift */; };
 		B28A592A2A6FCFED00431F39 /* SortFilterCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59292A6FCFED00431F39 /* SortFilterCell.swift */; };
+		B28A59302A739D3500431F39 /* EventFilterCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A592F2A739D3500431F39 /* EventFilterCell.swift */; };
 		B28A59132A6E98DB00431F39 /* CurationHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59122A6E98DB00431F39 /* CurationHeaderView.swift */; };
 		B28A59152A6E991100431F39 /* CurationFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59142A6E991100431F39 /* CurationFooterView.swift */; };
 		B28A59172A6E995500431F39 /* CurationEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59162A6E995500431F39 /* CurationEntity.swift */; };
@@ -268,6 +269,7 @@
 		B28A59212A6FB2B200431F39 /* ProductFilterInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFilterInteractor.swift; sourceTree = "<group>"; };
 		B28A59262A6FCE9700431F39 /* ProductFilterSectionLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFilterSectionLayout.swift; sourceTree = "<group>"; };
 		B28A59292A6FCFED00431F39 /* SortFilterCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortFilterCell.swift; sourceTree = "<group>"; };
+		B28A592F2A739D3500431F39 /* EventFilterCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventFilterCell.swift; sourceTree = "<group>"; };
 		B28A59122A6E98DB00431F39 /* CurationHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationHeaderView.swift; sourceTree = "<group>"; };
 		B28A59142A6E991100431F39 /* CurationFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationFooterView.swift; sourceTree = "<group>"; };
 		B28A59162A6E995500431F39 /* CurationEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationEntity.swift; sourceTree = "<group>"; };
@@ -597,6 +599,7 @@
 			isa = PBXGroup;
 			children = (
 				B28A59292A6FCFED00431F39 /* SortFilterCell.swift */,
+				B28A592F2A739D3500431F39 /* EventFilterCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -1396,6 +1399,7 @@
 				B2538B932A34551D00B7C3F0 /* LoggedInRouter.swift in Sources */,
 				BAB54A952A5949B700D45A80 /* ImageAssetKind+Splash.swift in Sources */,
 				BA87E3DE2A4629B5000A9DEC /* EventProductEntity.swift in Sources */,
+				B28A59302A739D3500431F39 /* EventFilterCell.swift in Sources */,
 				BAED882F2A24C3E600DA6257 /* RootRouter.swift in Sources */,
 				B2A5294B2A57F2220010656A /* LogoutPopupBuilder.swift in Sources */,
 				BA87E3D52A45D400000A9DEC /* GiftItemView.swift in Sources */,

--- a/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
+++ b/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		B28A59242A6FB2B200431F39 /* ProductFilterBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59202A6FB2B200431F39 /* ProductFilterBuilder.swift */; };
 		B28A59252A6FB2B200431F39 /* ProductFilterInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59212A6FB2B200431F39 /* ProductFilterInteractor.swift */; };
 		B28A59272A6FCE9700431F39 /* ProductFilterSectionLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59262A6FCE9700431F39 /* ProductFilterSectionLayout.swift */; };
+		B28A592A2A6FCFED00431F39 /* SortFilterCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59292A6FCFED00431F39 /* SortFilterCell.swift */; };
 		B28A59132A6E98DB00431F39 /* CurationHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59122A6E98DB00431F39 /* CurationHeaderView.swift */; };
 		B28A59152A6E991100431F39 /* CurationFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59142A6E991100431F39 /* CurationFooterView.swift */; };
 		B28A59172A6E995500431F39 /* CurationEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A59162A6E995500431F39 /* CurationEntity.swift */; };
@@ -266,6 +267,7 @@
 		B28A59202A6FB2B200431F39 /* ProductFilterBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFilterBuilder.swift; sourceTree = "<group>"; };
 		B28A59212A6FB2B200431F39 /* ProductFilterInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFilterInteractor.swift; sourceTree = "<group>"; };
 		B28A59262A6FCE9700431F39 /* ProductFilterSectionLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFilterSectionLayout.swift; sourceTree = "<group>"; };
+		B28A59292A6FCFED00431F39 /* SortFilterCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortFilterCell.swift; sourceTree = "<group>"; };
 		B28A59122A6E98DB00431F39 /* CurationHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationHeaderView.swift; sourceTree = "<group>"; };
 		B28A59142A6E991100431F39 /* CurationFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationFooterView.swift; sourceTree = "<group>"; };
 		B28A59162A6E995500431F39 /* CurationEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationEntity.swift; sourceTree = "<group>"; };
@@ -565,6 +567,7 @@
 		B28A591D2A6FB29200431F39 /* ProductFilter */ = {
 			isa = PBXGroup;
 			children = (
+				B28A59282A6FCF9600431F39 /* Cell */,
 				B28A591E2A6FB2B200431F39 /* ProductFilterRouter.swift */,
 				B28A591F2A6FB2B200431F39 /* ProductFilterViewController.swift */,
 				B28A59202A6FB2B200431F39 /* ProductFilterBuilder.swift */,
@@ -586,6 +589,14 @@
 			isa = PBXGroup;
 			children = (
 				B28A591A2A6E9F3D00431F39 /* CurationImageCell.swift */,
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
+		B28A59282A6FCF9600431F39 /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				B28A59292A6FCFED00431F39 /* SortFilterCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -1293,6 +1304,7 @@
 				F0D6FFAD2A39F97900C55E27 /* String+.swift in Sources */,
 				BA18075C2A2F189A00295398 /* UIButton+.swift in Sources */,
 				BA50FD042A680AA900721782 /* ProductSearchInteractor.swift in Sources */,
+				B28A592A2A6FCFED00431F39 /* SortFilterCell.swift in Sources */,
 				F0EE10A12A4B122A00B8DF4F /* UITableView+.swift in Sources */,
 				B28A59222A6FB2B200431F39 /* ProductFilterRouter.swift in Sources */,
 				B24CAAE22A55AC2B005BE499 /* NotificationListViewHolder.swift in Sources */,

--- a/Pyonsnal-Color/Pyonsnal-Color/Common/Button/FilterButton.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Common/Button/FilterButton.swift
@@ -45,6 +45,7 @@ final class FilterButton: UIButton {
     
     // MARK: - Private method
     private func configureUI() {
+        self.isEnabled = false
         self.titleLabel?.font = .body3m
         self.makeRounded(with: .spacing4)
         self.makeBorder(width: Size.borderWidth,

--- a/Pyonsnal-Color/Pyonsnal-Color/Common/Button/SortButton.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Common/Button/SortButton.swift
@@ -25,6 +25,7 @@ final class SortButton: UIButton {
     
     // MARK: - Private method
     private func configureUI() {
+        self.isEnabled = false
         self.titleLabel?.font = .body3m
         self.makeRounded(with: .spacing4)
         self.makeBorder(width: Size.borderWidth,

--- a/Pyonsnal-Color/Pyonsnal-Color/Common/Cell/ProductCell.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Common/Cell/ProductCell.swift
@@ -108,7 +108,7 @@ final class ProductCell: UICollectionViewCell {
         
         let eventTagLabel: UILabel = {
             let label = UILabel()
-            label.makeRounded(with: Spacing.spacing20.value)
+            label.makeRounded(with: .spacing20)
             label.backgroundColor = .green500
             label.font = .body4m
             label.textColor = .white

--- a/Pyonsnal-Color/Pyonsnal-Color/Common/Cell/RefreshFilterCell.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Common/Cell/RefreshFilterCell.swift
@@ -60,6 +60,7 @@ final class RefreshFilterCell: UICollectionViewCell {
         let refreshButton: UIButton = {
             let button = UIButton()
             button.setImage(.refreshFilter, for: .normal)
+            button.isEnabled = false
             return button
         }()
         

--- a/Pyonsnal-Color/Pyonsnal-Color/Common/Layout/TopCommonSectionLayout.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Common/Layout/TopCommonSectionLayout.swift
@@ -14,10 +14,11 @@ final class TopCommonSectionLayout {
         static let height: CGFloat = 44
     }
     
-    enum CategoryFilter {
+    enum Filter {
         static let estimatedWidth: CGFloat = 64
         static let cellHeight: CGFloat = 32
         static let height: CGFloat = 56
+        static let interSpacing: CGFloat = 8
     }
     
     private func convenienceStoreLayout(convenienceStore: [String]) -> NSCollectionLayoutSection {
@@ -58,22 +59,24 @@ final class TopCommonSectionLayout {
     
     private func filterLayout() -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
-            widthDimension: .estimated(ConvenienceStore.estimatedWidth),
+            widthDimension: .estimated(Filter.estimatedWidth),
             heightDimension: .fractionalHeight(1.0)
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         
         let groupSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(CategoryFilter.cellHeight)
+            widthDimension: .estimated(Filter.estimatedWidth),
+            heightDimension: .absolute(Filter.cellHeight)
         )
         let group = NSCollectionLayoutGroup.horizontal(
             layoutSize: groupSize,
             subitems: [item]
         )
-        group.interItemSpacing = .fixed(.spacing8)
+        
         let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = Filter.interSpacing
         section.contentInsets = .init(top: .spacing12, leading: 0, bottom: 0, trailing: 0)
+        section.orthogonalScrollingBehavior = .continuous
         return section
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/Common/NavigationBar/TitleNavigationView.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Common/NavigationBar/TitleNavigationView.swift
@@ -109,7 +109,7 @@ final class TitleNavigationView: UIView {
         }
         
         searchButton.snp.makeConstraints { make in
-            make.width.height.equalTo(.spacing24)
+            make.width.height.equalTo(Spacing.spacing24.value)
         }
     }
     

--- a/Pyonsnal-Color/Pyonsnal-Color/Common/NavigationBar/TitleNavigationView.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Common/NavigationBar/TitleNavigationView.swift
@@ -109,7 +109,7 @@ final class TitleNavigationView: UIView {
         }
         
         searchButton.snp.makeConstraints { make in
-            make.width.height.equalTo(Spacing.spacing24.value)
+            make.width.height.equalTo(.spacing24)
         }
     }
     

--- a/Pyonsnal-Color/Pyonsnal-Color/Entity/Filter/FilterCellItem.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Entity/Filter/FilterCellItem.swift
@@ -9,9 +9,12 @@ import Foundation
 
 struct FilterCellItem: Hashable {
     var filterUseType: FilterUseType = .category
-    var defaultText: String?
-    var isSelected: Bool = false
-    
+    var filter: FilterEntity?
+
+    static func == (lhs: FilterCellItem, rhs: FilterCellItem) -> Bool {
+        return lhs.filter?.defaultText == rhs.filter?.defaultText && lhs.filter?.filterType == rhs.filter?.filterType
+    }
+
     enum FilterUseType {
         case refresh
         case category

--- a/Pyonsnal-Color/Pyonsnal-Color/Entity/Filter/FilterEntity.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Entity/Filter/FilterEntity.swift
@@ -11,7 +11,7 @@ struct FilterDataEntity: Decodable {
     let data: [FilterEntity]
 }
 
-class FilterEntity: Decodable {
+struct FilterEntity: Decodable {
     let filterType: FilterType
     var defaultText: String? // 카테고리에 보여질 이름
     var isSelected: Bool = false

--- a/Pyonsnal-Color/Pyonsnal-Color/Entity/Filter/FilterEntity.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Entity/Filter/FilterEntity.swift
@@ -15,7 +15,7 @@ class FilterEntity: Decodable {
     let filterType: FilterType
     var defaultText: String? // 카테고리에 보여질 이름
     var isSelected: Bool = false
-    let filterItem: [FilterItemEntity]
+    var filterItem: [FilterItemEntity]
     
     init(filterType: FilterType, defaultText: String?, filterItem: [FilterItemEntity]) {
         self.filterType = filterType

--- a/Pyonsnal-Color/Pyonsnal-Color/Entity/Filter/FilterEntity.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Entity/Filter/FilterEntity.swift
@@ -24,10 +24,29 @@ class FilterEntity: Decodable {
     }
 }
 
-struct FilterItemEntity: Decodable {
+extension FilterEntity: Hashable {
+    static func == (lhs: FilterEntity, rhs: FilterEntity) -> Bool {
+        return lhs.filterItem == rhs.filterItem
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(filterItem)
+    }
+}
+
+struct FilterItemEntity: Decodable, Hashable {
     let name: String
     let code: Int
     var isSelected = false
+
+    enum CodingKeys: String, CodingKey {
+        case name, code
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(name)
+        hasher.combine(code)
+    }
 }
 
 struct FilterDummy {
@@ -45,13 +64,13 @@ struct FilterDummy {
                 filterType: .event,
                 defaultText: "행사",
                 filterItem: [
-                    FilterItemEntity(name: "1+1", code: 4),
-                    FilterItemEntity(name: "2+1", code: 5),
+                    FilterItemEntity(name: "1+1", code: 4, isSelected: true),
+                    FilterItemEntity(name: "2+1", code: 5, isSelected: true),
                     FilterItemEntity(name: "할인", code: 6),
                     FilterItemEntity(name: "증정", code: 7)
                 ]),
             FilterEntity(
-                filterType: .event,
+                filterType: .category,
                 defaultText: "카테고리",
                 filterItem: [
                     FilterItemEntity(name: "음료", code: 4),
@@ -62,7 +81,7 @@ struct FilterDummy {
                     FilterItemEntity(name: "베이커리", code: 7)
                 ]),
             FilterEntity(
-                filterType: .event,
+                filterType: .recommend,
                 defaultText: "상품 추천",
                 filterItem: [
                     FilterItemEntity(name: "다이어트", code: 8),

--- a/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeBuilder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeBuilder.swift
@@ -14,7 +14,8 @@ protocol EventHomeDependency: Dependency {
 final class EventHomeComponent: Component<EventHomeDependency>,
                                 ProductSearchDependency,
                                 EventDetailDependency,
-                                ProductDetailDependency {
+                                ProductDetailDependency,
+                                ProductFilterDependency {
     let productAPIService: ProductAPIService
     
     override init(dependency: EventHomeDependency) {
@@ -40,6 +41,7 @@ final class EventHomeBuilder: Builder<EventHomeDependency>, EventHomeBuildable {
         let viewController = EventHomeViewController()
         let eventDetailBuilder = EventDetailBuilder(dependency: component)
         let productDetail: ProductDetailBuilder = .init(dependency: component)
+        let productFilter: ProductFilterBuilder = .init(dependency: component)
         let interactor = EventHomeInteractor(
             presenter: viewController,
             dependency: dependency
@@ -50,6 +52,7 @@ final class EventHomeBuilder: Builder<EventHomeDependency>, EventHomeBuildable {
                                viewController: viewController,
                                productSearch: productSearch,
                                eventDetailBuilder: eventDetailBuilder,
-                               productDetail: productDetail)
+                               productDetail: productDetail,
+                               productFilter: productFilter)
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeInteractor.swift
@@ -26,6 +26,7 @@ protocol EventHomePresentable: Presentable {
     func update(with products: [EventProductEntity], banners: [EventBannerEntity], at store: ConvenienceStore)
     func didFinishPaging()
     func updateFilterItems(with items: [FilterItemEntity])
+    func updateSortFilter(type: FilterItemEntity)
 }
 
 protocol EventHomeListener: AnyObject {
@@ -151,7 +152,14 @@ final class EventHomeInteractor:
     }
     
     func applyFilterItems(_ items: [FilterItemEntity]) {
+        // TODO: 적용된 필터로 상품 목록 조회하기
         router?.detachProductFilter()
         presenter.updateFilterItems(with: items)
+    }
+    
+    func applySortFilter(type: FilterItemEntity) {
+        // TODO: 적용된 필터로 상품 목록 조회하기
+        router?.detachProductFilter()
+        presenter.updateSortFilter(type: type)
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeInteractor.swift
@@ -15,6 +15,8 @@ protocol EventHomeRouting: ViewableRouting {
     func detachEventDetail()
     func attachProductDetail(with brandProduct: ProductConvertable)
     func detachProductDetail()
+    func attachProductFilter(of filter: FilterEntity)
+    func detachProductFilter()
 }
 
 protocol EventHomePresentable: Presentable {
@@ -23,6 +25,7 @@ protocol EventHomePresentable: Presentable {
     func updateProducts(with products: [EventProductEntity], at store: ConvenienceStore)
     func update(with products: [EventProductEntity], banners: [EventBannerEntity], at store: ConvenienceStore)
     func didFinishPaging()
+    func updateFilterItems(with items: [FilterItemEntity])
 }
 
 protocol EventHomeListener: AnyObject {
@@ -135,5 +138,20 @@ final class EventHomeInteractor:
         if let lastPage = storeLastPages[store] {
             requestProducts(pageNumber: lastPage + 1, store: store)
         }
+    }
+    
+    func didSelectFilter(of filter: FilterEntity?) {
+        guard let filter else { return }
+        
+        router?.attachProductFilter(of: filter)
+    }
+    
+    func productFilterDidTapCloseButton() {
+        router?.detachProductFilter()
+    }
+    
+    func applyFilterItems(_ items: [FilterItemEntity]) {
+        router?.detachProductFilter()
+        presenter.updateFilterItems(with: items)
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeViewController.swift
@@ -145,7 +145,7 @@ final class EventHomeViewController: UIViewController,
     }
     
     private func setSortFilterDefaultText() {
-        FilterDummy.data.data.first(where: { $0.filterType == .sort })?.defaultText = "정렬"
+//        FilterDummy.data.data.first(where: { $0.filterType == .sort })?.defaultText = "정렬"
     }
     
     func makeFilterCellItem() -> [FilterCellItem] {
@@ -232,6 +232,21 @@ final class EventHomeViewController: UIViewController,
         print(items)
     }
     
+    func updateSortFilter(type: FilterItemEntity) {
+        guard var snapshot = dataSource?.snapshot(for: .filter) else { return }
+        let sortFilterIndex = 1, resetButtonIndex = 0
+        let currentItem = snapshot.items[sortFilterIndex]
+        let beforeItem = snapshot.items[resetButtonIndex]
+        
+        if case var .filter(item) = currentItem {
+            item.filter?.defaultText = type.name
+            snapshot.delete([currentItem])
+            snapshot.insert([.filter(filterItem: item)], after: beforeItem)
+            
+            dataSource?.apply(snapshot, to: .filter)
+        }
+    }
+    
 }
 
 // MARK: - UI Component
@@ -311,7 +326,7 @@ extension EventHomeViewController {
                 $0.top.equalTo(titleNavigationView.snp.bottom)
                 $0.leading.equalToSuperview().offset(Size.collectionViewLeaing)
                 $0.trailing.equalToSuperview().inset(Size.collectionViewLeaing)
-                let height = TopCommonSectionLayout.ConvenienceStore.height + TopCommonSectionLayout.CategoryFilter.height
+                let height = TopCommonSectionLayout.ConvenienceStore.height + TopCommonSectionLayout.Filter.height
                 $0.height.equalTo(height)
             }
             

--- a/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeViewController.swift
@@ -107,8 +107,10 @@ final class EventHomeViewController: UIViewController,
                     let cell: RefreshFilterCell = collectionView.dequeueReusableCell(for: indexPath)
                     return cell
                 case .category:
+                    guard let title = filterItem.filter?.defaultText else { return nil }
+                    
                     let cell: CategoryFilterCell = collectionView.dequeueReusableCell(for: indexPath)
-                    cell.configure(with: filterItem.filter?.defaultText ?? "", filterItem: [])
+                    cell.configure(with: title, filterItem: [])
                     return cell
                 }
             }
@@ -144,12 +146,7 @@ final class EventHomeViewController: UIViewController,
         dataSource?.apply(snapshot, animatingDifferences: true)
     }
     
-    private func setSortFilterDefaultText() {
-//        FilterDummy.data.data.first(where: { $0.filterType == .sort })?.defaultText = "정렬"
-    }
-    
     func makeFilterCellItem() -> [FilterCellItem] {
-        setSortFilterDefaultText()
         return FilterDummy.data.data.map { FilterCellItem(filter: $0) }
     }
     

--- a/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeViewController.swift
@@ -17,6 +17,7 @@ protocol EventHomePresentableListener: AnyObject {
     func didChangeStore(to store: ConvenienceStore)
     func didScrollToNextPage(store: ConvenienceStore)
     func didSelect(with brandProduct: ProductConvertable)
+    func didSelectFilter(of filter: FilterEntity?)
 }
 
 final class EventHomeViewController: UIViewController,
@@ -226,6 +227,11 @@ final class EventHomeViewController: UIViewController,
         isPaging = false
     }
     
+    func updateFilterItems(with items: [FilterItemEntity]) {
+        // TODO: 추가된 필터들 적용
+        print(items)
+    }
+    
 }
 
 // MARK: - UI Component
@@ -366,8 +372,16 @@ extension EventHomeViewController: UICollectionViewDelegate {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if collectionView == viewHolder.collectionView {
-            setSelectedConvenienceStoreCell(with: indexPath)
-            viewHolder.pageViewController.updatePage(indexPath.row)
+            guard let selectedItem = dataSource?.itemIdentifier(for: indexPath) else { return }
+            
+            switch selectedItem {
+            case .convenienceStore:
+                setSelectedConvenienceStoreCell(with: indexPath)
+                viewHolder.pageViewController.updatePage(indexPath.row)
+            case .filter(let filterItem):
+                listener?.didSelectFilter(of: filterItem.filter)
+            }
+
         }
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeViewController.swift
@@ -107,7 +107,7 @@ final class EventHomeViewController: UIViewController,
                     return cell
                 case .category:
                     let cell: CategoryFilterCell = collectionView.dequeueReusableCell(for: indexPath)
-                    cell.configure(with: filterItem.defaultText, filterItem: [])
+                    cell.configure(with: filterItem.filter?.defaultText ?? "", filterItem: [])
                     return cell
                 }
             }
@@ -149,9 +149,7 @@ final class EventHomeViewController: UIViewController,
     
     func makeFilterCellItem() -> [FilterCellItem] {
         setSortFilterDefaultText()
-        return FilterDummy.data.data.map { $0.defaultText }.map { defaultText in
-            FilterCellItem(defaultText: defaultText)
-        }
+        return FilterDummy.data.data.map { FilterCellItem(filter: $0) }
     }
     
     private func createLayout() -> UICollectionViewCompositionalLayout {

--- a/Pyonsnal-Color/Pyonsnal-Color/Extension/UIView+.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Extension/UIView+.swift
@@ -28,4 +28,8 @@ extension UIView {
         self.layer.borderWidth = width
         self.layer.borderColor = color
     }
+    
+    func removeBorder() {
+        self.layer.borderWidth = 0
+    }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/LogoutPopup/LogoutPopupViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/LogoutPopup/LogoutPopupViewController.swift
@@ -117,8 +117,8 @@ extension LogoutPopupViewController {
             enum Size {
                 static let topBottomMargin: CGFloat = 40
                 static let leftRightMargin: CGFloat = 20
-                static let titleStackViewSpacing: CGFloat = Spacing.spacing8.value
-                static let buttonStackViewSpacing: CGFloat = Spacing.spacing16.value
+                static let titleStackViewSpacing: CGFloat = .spacing8
+                static let buttonStackViewSpacing: CGFloat = .spacing16
                 static let popupWidth: CGFloat = 358
                 static let popupHeight: CGFloat = 228
                 static let buttonWidth: CGFloat = 151
@@ -130,7 +130,7 @@ extension LogoutPopupViewController {
         
         private let mainPopupView: UIView = {
             let view = UIView()
-            view.makeRounded(with: Spacing.spacing16.value)
+            view.makeRounded(with: .spacing16)
             view.backgroundColor = .white
             return view
         }()
@@ -168,7 +168,7 @@ extension LogoutPopupViewController {
         let dismissButton: UIButton = {
             let button = UIButton()
             button.makeBorder(width: 1, color: UIColor.black.cgColor)
-            button.makeRounded(with: Spacing.spacing16.value)
+            button.makeRounded(with: .spacing16)
 
             return button
         }()
@@ -176,7 +176,7 @@ extension LogoutPopupViewController {
         let confirmButton: UIButton = {
             let button = UIButton()
             button.makeBorder(width: 1, color: UIColor.black.cgColor)
-            button.makeRounded(with: Spacing.spacing16.value)
+            button.makeRounded(with: .spacing16)
             button.backgroundColor = .black
             return button
         }()

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/CategoryFilterCell.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/CategoryFilterCell.swift
@@ -1,0 +1,113 @@
+//
+//  CategoryFilterCell.swift
+//  Pyonsnal-Color
+//
+//  Created by 김인호 on 2023/07/28.
+//
+
+import UIKit
+import SnapKit
+
+final class CategoryFilterCell: UICollectionViewCell {
+    
+    enum Image {
+        static let checkMark = "checkmark"
+    }
+    
+    enum Size {
+        static let selectedBorderWidth: CGFloat = 2
+        static let unselectedBorderWidth: CGFloat = 1
+    }
+    
+    private let viewHolder = ViewHolder()
+    
+    override var isSelected: Bool {
+        didSet {
+            isSelected ? setSelectedState() : setUnselectedState()
+        }
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        viewHolder.place(in: contentView)
+        viewHolder.configureConstraints(for: contentView)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func configureCell(title: String, isSelected: Bool) {
+        viewHolder.titleLabel.text = title
+        isSelected ? setSelectedState() : setUnselectedState()
+    }
+    
+    private func setSelectedState() {
+        viewHolder.iconImageView.makeBorder(
+            width: Size.selectedBorderWidth,
+            color: UIColor.red500.cgColor
+        )
+        viewHolder.titleLabel.textColor = .red500
+    }
+    
+    private func setUnselectedState() {
+        viewHolder.iconImageView.makeBorder(
+            width: Size.unselectedBorderWidth,
+            color: UIColor.gray200.cgColor
+        )
+        viewHolder.titleLabel.textColor = .black
+    }
+}
+
+extension CategoryFilterCell {
+    final class ViewHolder: ViewHolderable {
+        
+        enum Size {
+            static let spacing: CGFloat = 8
+            static let iconBorderWidth: CGFloat = 1
+            static let iconSize: CGFloat = 80
+        }
+        
+        private let containerStackView: UIStackView = {
+            let stackView = UIStackView()
+            stackView.axis = .vertical
+            stackView.alignment = .center
+            stackView.spacing = Size.spacing
+            return stackView
+        }()
+        
+        let iconImageView: UIImageView = {
+            let imageView = UIImageView()
+            imageView.makeBorder(width: Size.iconBorderWidth, color: UIColor.gray200.cgColor)
+            imageView.makeRounded(with: Size.iconSize / 2)
+            imageView.backgroundColor = .white
+            return imageView
+        }()
+        
+        let titleLabel: UILabel = {
+            let label = UILabel()
+            label.font = .body3m
+            label.textColor = .black
+            return label
+        }()
+        
+        func place(in view: UIView) {
+            view.addSubview(containerStackView)
+            
+            containerStackView.addArrangedSubview(iconImageView)
+            containerStackView.addArrangedSubview(titleLabel)
+        }
+        
+        func configureConstraints(for view: UIView) {
+            containerStackView.snp.makeConstraints {
+                $0.leading.equalTo(view)
+                $0.centerY.equalTo(view)
+            }
+            
+            iconImageView.snp.makeConstraints {
+                $0.width.height.equalTo(Size.iconSize)
+            }
+        }
+    }
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/EventFilterCell.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/EventFilterCell.swift
@@ -1,0 +1,118 @@
+//
+//  EventFilterCell.swift
+//  Pyonsnal-Color
+//
+//  Created by 김인호 on 2023/07/28.
+//
+
+import UIKit
+import SnapKit
+
+final class EventFilterCell: UICollectionViewCell {
+    
+    enum Image {
+        static let checkMark = "checkmark"
+    }
+    
+    enum Size {
+        static let checkButtonBorderWidth: CGFloat = 1.6
+    }
+    
+    private let viewHolder = ViewHolder()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        viewHolder.place(in: contentView)
+        viewHolder.configureConstraints(for: contentView)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func hideCheckMark() {
+        viewHolder.checkButton.isHidden = isSelected ? false : true
+    }
+    
+    func configureCell(title: String, isSelected: Bool) {
+        viewHolder.titleLabel.text = title
+        
+        if isSelected {
+            let configuration: UIImage.SymbolConfiguration = .init(weight: .bold)
+            let checkImage = UIImage(systemName: Image.checkMark, withConfiguration: configuration)
+            
+            viewHolder.titleLabel.textColor = .red500
+            viewHolder.checkButton.backgroundColor = .red500
+            viewHolder.checkButton.setImage(checkImage, for: .normal)
+            viewHolder.checkButton.imageView?.sizeToFit()
+            viewHolder.checkButton.removeBorder()
+        } else {
+            viewHolder.titleLabel.textColor = .black
+            viewHolder.checkButton.backgroundColor = .white
+            viewHolder.checkButton.imageView?.image = nil
+            viewHolder.checkButton.makeBorder(
+                width: Size.checkButtonBorderWidth,
+                color: UIColor.gray300.cgColor
+            )
+        }
+    }
+}
+
+extension EventFilterCell {
+    final class ViewHolder: ViewHolderable {
+        
+        enum Size {
+            static let spacing: CGFloat = 10
+            static let checkButtonBorderWidth: CGFloat = 1.6
+            static let checkButtonRadius: CGFloat = 10
+            static let checkButtonSize: CGFloat = 20
+            static let checkButtonInset: UIEdgeInsets = .init(top: 5, left: 5, bottom: 5, right: 5)
+        }
+        
+        private let containerStackView: UIStackView = {
+            let stackView = UIStackView()
+            stackView.axis = .horizontal
+            stackView.distribution = .equalSpacing
+            stackView.spacing = Size.spacing
+            return stackView
+        }()
+        
+        let checkButton: UIButton = {
+            let button = UIButton()
+            button.makeBorder(width: Size.checkButtonBorderWidth, color: UIColor.gray300.cgColor)
+            button.makeRounded(with: Size.checkButtonRadius)
+            button.imageEdgeInsets = Size.checkButtonInset
+            button.imageView?.contentMode = .center
+            button.imageView?.clipsToBounds = false
+            button.backgroundColor = .white
+            button.tintColor = .white
+            return button
+        }()
+        
+        let titleLabel: UILabel = {
+            let label = UILabel()
+            label.font = .body2m
+            label.textColor = .black
+            return label
+        }()
+        
+        func place(in view: UIView) {
+            view.addSubview(containerStackView)
+            
+            containerStackView.addArrangedSubview(checkButton)
+            containerStackView.addArrangedSubview(titleLabel)
+        }
+        
+        func configureConstraints(for view: UIView) {
+            containerStackView.snp.makeConstraints {
+                $0.leading.equalTo(view)
+                $0.centerY.equalTo(view)
+            }
+            
+            checkButton.snp.makeConstraints {
+                $0.width.height.equalTo(Size.checkButtonSize)
+            }
+        }
+    }
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/EventFilterCell.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/EventFilterCell.swift
@@ -37,9 +37,9 @@ final class EventFilterCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    func configureCell(title: String, isSelected: Bool) {
-        viewHolder.titleLabel.text = title
-        isSelected ? setSelectedState() : setUnselectedState()
+    func configureCell(filterItem: FilterItemEntity) {
+        viewHolder.titleLabel.text = filterItem.name
+        isSelected = filterItem.isSelected
     }
     
     private func setSelectedState() {

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/EventFilterCell.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/EventFilterCell.swift
@@ -37,10 +37,6 @@ final class EventFilterCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    func hideCheckMark() {
-        viewHolder.checkButton.isHidden = isSelected ? false : true
-    }
-    
     func configureCell(title: String, isSelected: Bool) {
         viewHolder.titleLabel.text = title
         isSelected ? setSelectedState() : setUnselectedState()
@@ -49,19 +45,19 @@ final class EventFilterCell: UICollectionViewCell {
     private func setSelectedState() {
         let configuration: UIImage.SymbolConfiguration = .init(weight: .bold)
         let checkImage = UIImage(systemName: Image.checkMark, withConfiguration: configuration)
+        checkImage?.withTintColor(.white)
         
         viewHolder.titleLabel.textColor = .red500
-        viewHolder.checkButton.backgroundColor = .red500
-        viewHolder.checkButton.setImage(checkImage, for: .normal)
-        viewHolder.checkButton.imageView?.sizeToFit()
-        viewHolder.checkButton.removeBorder()
+        viewHolder.checkImageView.backgroundColor = .red500
+        viewHolder.checkImageView.image = checkImage
+        viewHolder.checkImageView.removeBorder()
     }
     
     private func setUnselectedState() {
         viewHolder.titleLabel.textColor = .black
-        viewHolder.checkButton.backgroundColor = .white
-        viewHolder.checkButton.imageView?.image = nil
-        viewHolder.checkButton.makeBorder(
+        viewHolder.checkImageView.backgroundColor = .white
+        viewHolder.checkImageView.image = nil
+        viewHolder.checkImageView.makeBorder(
             width: Size.checkButtonBorderWidth,
             color: UIColor.gray300.cgColor
         )
@@ -73,10 +69,10 @@ extension EventFilterCell {
         
         enum Size {
             static let spacing: CGFloat = 10
-            static let checkButtonBorderWidth: CGFloat = 1.6
-            static let checkButtonRadius: CGFloat = 10
-            static let checkButtonSize: CGFloat = 20
-            static let checkButtonInset: UIEdgeInsets = .init(top: 5, left: 5, bottom: 5, right: 5)
+            static let checkImageBorderWidth: CGFloat = 1.6
+            static let checkImageRadius: CGFloat = 10
+            static let checkImageSize: CGFloat = 20
+            static let checkImageInset: UIEdgeInsets = .init(top: 5, left: 5, bottom: 5, right: 5)
         }
         
         private let containerStackView: UIStackView = {
@@ -87,16 +83,14 @@ extension EventFilterCell {
             return stackView
         }()
         
-        let checkButton: UIButton = {
-            let button = UIButton()
-            button.makeBorder(width: Size.checkButtonBorderWidth, color: UIColor.gray300.cgColor)
-            button.makeRounded(with: Size.checkButtonRadius)
-            button.imageEdgeInsets = Size.checkButtonInset
-            button.imageView?.contentMode = .center
-            button.imageView?.clipsToBounds = false
-            button.backgroundColor = .white
-            button.tintColor = .white
-            return button
+        let checkImageView: UIImageView = {
+            let imageView = UIImageView()
+            imageView.makeBorder(width: Size.checkImageBorderWidth, color: UIColor.gray300.cgColor)
+            imageView.makeRounded(with: Size.checkImageRadius)
+            imageView.layoutMargins = Size.checkImageInset
+            imageView.backgroundColor = .white
+            imageView.tintColor = .white
+            return imageView
         }()
         
         let titleLabel: UILabel = {
@@ -109,7 +103,7 @@ extension EventFilterCell {
         func place(in view: UIView) {
             view.addSubview(containerStackView)
             
-            containerStackView.addArrangedSubview(checkButton)
+            containerStackView.addArrangedSubview(checkImageView)
             containerStackView.addArrangedSubview(titleLabel)
         }
         
@@ -119,8 +113,8 @@ extension EventFilterCell {
                 $0.centerY.equalTo(view)
             }
             
-            checkButton.snp.makeConstraints {
-                $0.width.height.equalTo(Size.checkButtonSize)
+            checkImageView.snp.makeConstraints {
+                $0.width.height.equalTo(Size.checkImageSize)
             }
         }
     }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/EventFilterCell.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/EventFilterCell.swift
@@ -20,6 +20,12 @@ final class EventFilterCell: UICollectionViewCell {
     
     private let viewHolder = ViewHolder()
     
+    override var isSelected: Bool {
+        didSet {
+            isSelected ? setSelectedState() : setUnselectedState()
+        }
+    }
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         
@@ -37,25 +43,28 @@ final class EventFilterCell: UICollectionViewCell {
     
     func configureCell(title: String, isSelected: Bool) {
         viewHolder.titleLabel.text = title
+        isSelected ? setSelectedState() : setUnselectedState()
+    }
+    
+    private func setSelectedState() {
+        let configuration: UIImage.SymbolConfiguration = .init(weight: .bold)
+        let checkImage = UIImage(systemName: Image.checkMark, withConfiguration: configuration)
         
-        if isSelected {
-            let configuration: UIImage.SymbolConfiguration = .init(weight: .bold)
-            let checkImage = UIImage(systemName: Image.checkMark, withConfiguration: configuration)
-            
-            viewHolder.titleLabel.textColor = .red500
-            viewHolder.checkButton.backgroundColor = .red500
-            viewHolder.checkButton.setImage(checkImage, for: .normal)
-            viewHolder.checkButton.imageView?.sizeToFit()
-            viewHolder.checkButton.removeBorder()
-        } else {
-            viewHolder.titleLabel.textColor = .black
-            viewHolder.checkButton.backgroundColor = .white
-            viewHolder.checkButton.imageView?.image = nil
-            viewHolder.checkButton.makeBorder(
-                width: Size.checkButtonBorderWidth,
-                color: UIColor.gray300.cgColor
-            )
-        }
+        viewHolder.titleLabel.textColor = .red500
+        viewHolder.checkButton.backgroundColor = .red500
+        viewHolder.checkButton.setImage(checkImage, for: .normal)
+        viewHolder.checkButton.imageView?.sizeToFit()
+        viewHolder.checkButton.removeBorder()
+    }
+    
+    private func setUnselectedState() {
+        viewHolder.titleLabel.textColor = .black
+        viewHolder.checkButton.backgroundColor = .white
+        viewHolder.checkButton.imageView?.image = nil
+        viewHolder.checkButton.makeBorder(
+            width: Size.checkButtonBorderWidth,
+            color: UIColor.gray300.cgColor
+        )
     }
 }
 

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/EventFilterCell.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/EventFilterCell.swift
@@ -10,14 +10,6 @@ import SnapKit
 
 final class EventFilterCell: UICollectionViewCell {
     
-    enum Image {
-        static let checkMark = "checkmark"
-    }
-    
-    enum Size {
-        static let checkButtonBorderWidth: CGFloat = 1.6
-    }
-    
     private let viewHolder = ViewHolder()
     
     override var isSelected: Bool {
@@ -43,24 +35,13 @@ final class EventFilterCell: UICollectionViewCell {
     }
     
     private func setSelectedState() {
-        let configuration: UIImage.SymbolConfiguration = .init(weight: .bold)
-        let checkImage = UIImage(systemName: Image.checkMark, withConfiguration: configuration)
-        checkImage?.withTintColor(.white)
-        
+        viewHolder.checkButton.setImage(.checkSelectedRed, for: .normal)
         viewHolder.titleLabel.textColor = .red500
-        viewHolder.checkImageView.backgroundColor = .red500
-        viewHolder.checkImageView.image = checkImage
-        viewHolder.checkImageView.removeBorder()
     }
     
     private func setUnselectedState() {
         viewHolder.titleLabel.textColor = .black
-        viewHolder.checkImageView.backgroundColor = .white
-        viewHolder.checkImageView.image = nil
-        viewHolder.checkImageView.makeBorder(
-            width: Size.checkButtonBorderWidth,
-            color: UIColor.gray300.cgColor
-        )
+        viewHolder.checkButton.setImage(.check, for: .normal)
     }
 }
 
@@ -69,10 +50,8 @@ extension EventFilterCell {
         
         enum Size {
             static let spacing: CGFloat = 10
-            static let checkImageBorderWidth: CGFloat = 1.6
-            static let checkImageRadius: CGFloat = 10
-            static let checkImageSize: CGFloat = 20
-            static let checkImageInset: UIEdgeInsets = .init(top: 5, left: 5, bottom: 5, right: 5)
+            static let checkButtonRadius: CGFloat = 10
+            static let checkButtonSize: CGFloat = 20
         }
         
         private let containerStackView: UIStackView = {
@@ -83,14 +62,12 @@ extension EventFilterCell {
             return stackView
         }()
         
-        let checkImageView: UIImageView = {
-            let imageView = UIImageView()
-            imageView.makeBorder(width: Size.checkImageBorderWidth, color: UIColor.gray300.cgColor)
-            imageView.makeRounded(with: Size.checkImageRadius)
-            imageView.layoutMargins = Size.checkImageInset
-            imageView.backgroundColor = .white
-            imageView.tintColor = .white
-            return imageView
+        let checkButton: UIButton = {
+            let button = UIButton()
+            button.makeRounded(with: Size.checkButtonRadius)
+            button.setImage(.check, for: .normal)
+            button.isUserInteractionEnabled = false
+            return button
         }()
         
         let titleLabel: UILabel = {
@@ -103,7 +80,7 @@ extension EventFilterCell {
         func place(in view: UIView) {
             view.addSubview(containerStackView)
             
-            containerStackView.addArrangedSubview(checkImageView)
+            containerStackView.addArrangedSubview(checkButton)
             containerStackView.addArrangedSubview(titleLabel)
         }
         
@@ -113,8 +90,8 @@ extension EventFilterCell {
                 $0.centerY.equalTo(view)
             }
             
-            checkImageView.snp.makeConstraints {
-                $0.width.height.equalTo(Size.checkImageSize)
+            checkButton.snp.makeConstraints {
+                $0.width.height.equalTo(Size.checkButtonSize)
             }
         }
     }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/RecommendFilterCell.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/RecommendFilterCell.swift
@@ -38,9 +38,9 @@ final class RecommendFilterCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    func configureCell(title: String, isSelected: Bool) {
-        viewHolder.titleLabel.text = title
-        isSelected ? setSelectedState() : setUnselectedState()
+    func configureCell(filterItem: FilterItemEntity) {
+        viewHolder.titleLabel.text = filterItem.name
+        isSelected = filterItem.isSelected
     }
     
     private func setSelectedState() {

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/RecommendFilterCell.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/RecommendFilterCell.swift
@@ -1,5 +1,5 @@
 //
-//  CategoryFilterCell.swift
+//  RecommendFilterCell.swift
 //  Pyonsnal-Color
 //
 //  Created by 김인호 on 2023/07/28.
@@ -8,7 +8,7 @@
 import UIKit
 import SnapKit
 
-final class CategoryFilterCell: UICollectionViewCell {
+final class RecommendFilterCell: UICollectionViewCell {
     
     enum Image {
         static let checkMark = "checkmark"
@@ -60,7 +60,7 @@ final class CategoryFilterCell: UICollectionViewCell {
     }
 }
 
-extension CategoryFilterCell {
+extension RecommendFilterCell {
     final class ViewHolder: ViewHolderable {
         
         enum Size {

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/SortFilterCell.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/SortFilterCell.swift
@@ -12,6 +12,12 @@ final class SortFilterCell: UICollectionViewCell {
     
     private let viewHolder = ViewHolder()
     
+    override var isSelected: Bool {
+        didSet {
+            isSelected ? setSelectedState() : setUnselectedState()
+        }
+    }
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         
@@ -29,12 +35,17 @@ final class SortFilterCell: UICollectionViewCell {
     
     func configureCell(title: String, isSelected: Bool) {
         viewHolder.titleLabel.text = title
-        
-        if isSelected {
-            viewHolder.titleLabel.textColor = .red500
-        } else {
-            viewHolder.checkButton.isHidden = true
-        }
+        isSelected ? setSelectedState() : setUnselectedState()
+    }
+    
+    private func setSelectedState() {
+        viewHolder.titleLabel.textColor = .red500
+        viewHolder.checkButton.isHidden = false
+    }
+    
+    private func setUnselectedState() {
+        viewHolder.titleLabel.textColor = .black
+        viewHolder.checkButton.isHidden = true
     }
 }
 

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/SortFilterCell.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/SortFilterCell.swift
@@ -33,9 +33,9 @@ final class SortFilterCell: UICollectionViewCell {
         viewHolder.checkButton.isHidden = isSelected ? false : true
     }
     
-    func configureCell(title: String, isSelected: Bool) {
-        viewHolder.titleLabel.text = title
-        isSelected ? setSelectedState() : setUnselectedState()
+    func configureCell(filterItem: FilterItemEntity) {
+        viewHolder.titleLabel.text = filterItem.name
+        isSelected = filterItem.isSelected
     }
     
     private func setSelectedState() {

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/SortFilterCell.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/SortFilterCell.swift
@@ -1,0 +1,84 @@
+//
+//  SortFilterCell.swift
+//  Pyonsnal-Color
+//
+//  Created by 김인호 on 2023/07/25.
+//
+
+import UIKit
+import SnapKit
+
+final class SortFilterCell: UICollectionViewCell {
+    
+    enum Sort: String, CaseIterable {
+        case recent = "최신순"
+        case lowestPrice = "낮은 가격 순"
+        case highestPrice = "높은 가격 순"
+    }
+    
+    private let viewHolder = ViewHolder()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        viewHolder.place(in: contentView)
+        viewHolder.configureConstraints(for: contentView)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func hideCheckMakr() {
+        viewHolder.checkButton.isHidden = isSelected ? false : true
+    }
+    
+    func configureCell(at index: Int) {
+        let title = Sort.allCases[index].rawValue
+        
+        viewHolder.titleLabel.text = title
+    }
+}
+
+extension SortFilterCell {
+    final class ViewHolder: ViewHolderable {
+        
+        enum Image {
+            static let checkMark = "checkmark"
+        }
+        
+        private let containerStackView: UIStackView = {
+            let stackView = UIStackView()
+            stackView.axis = .horizontal
+            stackView.distribution = .equalSpacing
+            return stackView
+        }()
+        
+        let titleLabel: UILabel = {
+            let label = UILabel()
+            label.font = .body2m
+            label.textColor = .black
+            return label
+        }()
+        
+        let checkButton: UIButton = {
+            let button = UIButton()
+            button.setImage(.init(systemName: Image.checkMark), for: .normal)
+            button.tintColor = .red500
+            return button
+        }()
+        
+        func place(in view: UIView) {
+            view.addSubview(containerStackView)
+            
+            containerStackView.addArrangedSubview(titleLabel)
+            containerStackView.addArrangedSubview(checkButton)
+        }
+        
+        func configureConstraints(for view: UIView) {
+            containerStackView.snp.makeConstraints {
+                $0.edges.equalTo(view)
+            }
+        }
+    }
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/SortFilterCell.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/SortFilterCell.swift
@@ -72,8 +72,8 @@ extension SortFilterCell {
         
         let checkButton: UIButton = {
             let button = UIButton()
-            button.setImage(.init(systemName: Image.checkMark), for: .normal)
-            button.tintColor = .red500
+            button.setImage(.iconCheck, for: .normal)
+            button.setImageTintColor(with: .red500)
             return button
         }()
         

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/SortFilterCell.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/Cell/SortFilterCell.swift
@@ -10,12 +10,6 @@ import SnapKit
 
 final class SortFilterCell: UICollectionViewCell {
     
-    enum Sort: String, CaseIterable {
-        case recent = "최신순"
-        case lowestPrice = "낮은 가격 순"
-        case highestPrice = "높은 가격 순"
-    }
-    
     private let viewHolder = ViewHolder()
     
     override init(frame: CGRect) {
@@ -29,14 +23,18 @@ final class SortFilterCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    func hideCheckMakr() {
+    func hideCheckMark() {
         viewHolder.checkButton.isHidden = isSelected ? false : true
     }
     
-    func configureCell(at index: Int) {
-        let title = Sort.allCases[index].rawValue
-        
+    func configureCell(title: String, isSelected: Bool) {
         viewHolder.titleLabel.text = title
+        
+        if isSelected {
+            viewHolder.titleLabel.textColor = .red500
+        } else {
+            viewHolder.checkButton.isHidden = true
+        }
     }
 }
 

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterBuilder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterBuilder.swift
@@ -22,7 +22,7 @@ final class ProductFilterComponent: Component<ProductFilterDependency> {
 protocol ProductFilterBuildable: Buildable {
     func build(
         withListener listener: ProductFilterListener,
-        filterType: ProductFilterViewController.Section
+        filterEntity: FilterEntity
     ) -> ProductFilterRouting
 }
 
@@ -34,10 +34,10 @@ final class ProductFilterBuilder: Builder<ProductFilterDependency>, ProductFilte
     
     func build(
         withListener listener: ProductFilterListener,
-        filterType: ProductFilterViewController.Section
+        filterEntity: FilterEntity
     ) -> ProductFilterRouting {
         let component = ProductFilterComponent(dependency: dependency)
-        let viewController = ProductFilterViewController(filterType: filterType)
+        let viewController = ProductFilterViewController(filterEntity: filterEntity)
         let interactor = ProductFilterInteractor(presenter: viewController)
         interactor.listener = listener
         return ProductFilterRouter(interactor: interactor, viewController: viewController)

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterBuilder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterBuilder.swift
@@ -20,7 +20,10 @@ final class ProductFilterComponent: Component<ProductFilterDependency> {
 // MARK: - Builder
 
 protocol ProductFilterBuildable: Buildable {
-    func build(withListener listener: ProductFilterListener) -> ProductFilterRouting
+    func build(
+        withListener listener: ProductFilterListener,
+        filterType: ProductFilterViewController.Section
+    ) -> ProductFilterRouting
 }
 
 final class ProductFilterBuilder: Builder<ProductFilterDependency>, ProductFilterBuildable {
@@ -28,10 +31,13 @@ final class ProductFilterBuilder: Builder<ProductFilterDependency>, ProductFilte
     override init(dependency: ProductFilterDependency) {
         super.init(dependency: dependency)
     }
-
-    func build(withListener listener: ProductFilterListener) -> ProductFilterRouting {
+    
+    func build(
+        withListener listener: ProductFilterListener,
+        filterType: ProductFilterViewController.Section
+    ) -> ProductFilterRouting {
         let component = ProductFilterComponent(dependency: dependency)
-        let viewController = ProductFilterViewController()
+        let viewController = ProductFilterViewController(filterType: filterType)
         let interactor = ProductFilterInteractor(presenter: viewController)
         interactor.listener = listener
         return ProductFilterRouter(interactor: interactor, viewController: viewController)

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterBuilder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterBuilder.swift
@@ -1,0 +1,39 @@
+//
+//  ProductFilterBuilder.swift
+//  Pyonsnal-Color
+//
+//  Created by 김인호 on 2023/07/25.
+//
+
+import ModernRIBs
+
+protocol ProductFilterDependency: Dependency {
+    // TODO: Declare the set of dependencies required by this RIB, but cannot be
+    // created by this RIB.
+}
+
+final class ProductFilterComponent: Component<ProductFilterDependency> {
+
+    // TODO: Declare 'fileprivate' dependencies that are only used by this RIB.
+}
+
+// MARK: - Builder
+
+protocol ProductFilterBuildable: Buildable {
+    func build(withListener listener: ProductFilterListener) -> ProductFilterRouting
+}
+
+final class ProductFilterBuilder: Builder<ProductFilterDependency>, ProductFilterBuildable {
+
+    override init(dependency: ProductFilterDependency) {
+        super.init(dependency: dependency)
+    }
+
+    func build(withListener listener: ProductFilterListener) -> ProductFilterRouting {
+        let component = ProductFilterComponent(dependency: dependency)
+        let viewController = ProductFilterViewController()
+        let interactor = ProductFilterInteractor(presenter: viewController)
+        interactor.listener = listener
+        return ProductFilterRouter(interactor: interactor, viewController: viewController)
+    }
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterInteractor.swift
@@ -8,16 +8,13 @@
 import ModernRIBs
 
 protocol ProductFilterRouting: ViewableRouting {
-    // TODO: Declare methods the interactor can invoke to manage sub-tree via the router.
 }
 
 protocol ProductFilterPresentable: Presentable {
     var listener: ProductFilterPresentableListener? { get set }
-    // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 
 protocol ProductFilterListener: AnyObject {
-    // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
 }
 
 final class ProductFilterInteractor: PresentableInteractor<ProductFilterPresentable>, ProductFilterInteractable, ProductFilterPresentableListener {
@@ -25,8 +22,6 @@ final class ProductFilterInteractor: PresentableInteractor<ProductFilterPresenta
     weak var router: ProductFilterRouting?
     weak var listener: ProductFilterListener?
 
-    // TODO: Add additional dependencies to constructor. Do not perform any logic
-    // in constructor.
     override init(presenter: ProductFilterPresentable) {
         super.init(presenter: presenter)
         presenter.listener = self
@@ -34,11 +29,17 @@ final class ProductFilterInteractor: PresentableInteractor<ProductFilterPresenta
 
     override func didBecomeActive() {
         super.didBecomeActive()
-        // TODO: Implement business logic here.
     }
 
     override func willResignActive() {
         super.willResignActive()
-        // TODO: Pause any business logic.
+    }
+    
+    func didTapApplyButton(with selectedItems: [String]) {
+        // TODO: 상위 리블렛에 전달 & 화면 dismiss
+    }
+    
+    func didTapCloseButton() {
+        // TODO: 화면 dismiss
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterInteractor.swift
@@ -1,0 +1,44 @@
+//
+//  ProductFilterInteractor.swift
+//  Pyonsnal-Color
+//
+//  Created by 김인호 on 2023/07/25.
+//
+
+import ModernRIBs
+
+protocol ProductFilterRouting: ViewableRouting {
+    // TODO: Declare methods the interactor can invoke to manage sub-tree via the router.
+}
+
+protocol ProductFilterPresentable: Presentable {
+    var listener: ProductFilterPresentableListener? { get set }
+    // TODO: Declare methods the interactor can invoke the presenter to present data.
+}
+
+protocol ProductFilterListener: AnyObject {
+    // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
+}
+
+final class ProductFilterInteractor: PresentableInteractor<ProductFilterPresentable>, ProductFilterInteractable, ProductFilterPresentableListener {
+
+    weak var router: ProductFilterRouting?
+    weak var listener: ProductFilterListener?
+
+    // TODO: Add additional dependencies to constructor. Do not perform any logic
+    // in constructor.
+    override init(presenter: ProductFilterPresentable) {
+        super.init(presenter: presenter)
+        presenter.listener = self
+    }
+
+    override func didBecomeActive() {
+        super.didBecomeActive()
+        // TODO: Implement business logic here.
+    }
+
+    override func willResignActive() {
+        super.willResignActive()
+        // TODO: Pause any business logic.
+    }
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterInteractor.swift
@@ -15,6 +15,7 @@ protocol ProductFilterPresentable: Presentable {
 }
 
 protocol ProductFilterListener: AnyObject {
+    func applyFilterItems(_ items: [FilterItemEntity])
     func productFilterDidTapCloseButton()
 }
 
@@ -36,8 +37,8 @@ final class ProductFilterInteractor: PresentableInteractor<ProductFilterPresenta
         super.willResignActive()
     }
     
-    func didTapApplyButton(with selectedItems: [String]) {
-        // TODO: 상위 리블렛에 전달 & 화면 dismiss
+    func didTapApplyButton(with selectedItems: [FilterItemEntity]) {
+        listener?.applyFilterItems(selectedItems)
     }
     
     func didTapCloseButton() {

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterInteractor.swift
@@ -15,6 +15,7 @@ protocol ProductFilterPresentable: Presentable {
 }
 
 protocol ProductFilterListener: AnyObject {
+    func productFilterDidTapCloseButton()
 }
 
 final class ProductFilterInteractor: PresentableInteractor<ProductFilterPresentable>, ProductFilterInteractable, ProductFilterPresentableListener {
@@ -40,6 +41,6 @@ final class ProductFilterInteractor: PresentableInteractor<ProductFilterPresenta
     }
     
     func didTapCloseButton() {
-        // TODO: 화면 dismiss
+        listener?.productFilterDidTapCloseButton()
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterInteractor.swift
@@ -16,6 +16,7 @@ protocol ProductFilterPresentable: Presentable {
 
 protocol ProductFilterListener: AnyObject {
     func applyFilterItems(_ items: [FilterItemEntity])
+    func applySortFilter(type: FilterItemEntity)
     func productFilterDidTapCloseButton()
 }
 
@@ -39,6 +40,10 @@ final class ProductFilterInteractor: PresentableInteractor<ProductFilterPresenta
     
     func didTapApplyButton(with selectedItems: [FilterItemEntity]) {
         listener?.applyFilterItems(selectedItems)
+    }
+    
+    func didSelectSortFilter(type: FilterItemEntity) {
+        listener?.applySortFilter(type: type)
     }
     
     func didTapCloseButton() {

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterRouter.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterRouter.swift
@@ -1,0 +1,26 @@
+//
+//  ProductFilterRouter.swift
+//  Pyonsnal-Color
+//
+//  Created by 김인호 on 2023/07/25.
+//
+
+import ModernRIBs
+
+protocol ProductFilterInteractable: Interactable {
+    var router: ProductFilterRouting? { get set }
+    var listener: ProductFilterListener? { get set }
+}
+
+protocol ProductFilterViewControllable: ViewControllable {
+    // TODO: Declare methods the router invokes to manipulate the view hierarchy.
+}
+
+final class ProductFilterRouter: ViewableRouter<ProductFilterInteractable, ProductFilterViewControllable>, ProductFilterRouting {
+
+    // TODO: Constructor inject child builder protocols to allow building children.
+    override init(interactor: ProductFilterInteractable, viewController: ProductFilterViewControllable) {
+        super.init(interactor: interactor, viewController: viewController)
+        interactor.router = self
+    }
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterSectionLayout.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterSectionLayout.swift
@@ -52,6 +52,7 @@ final class ProductFilterSectionLayout {
         group.interItemSpacing = .fixed(.spacing12)
         
         let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = .spacing12
         return section
     }
     

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterSectionLayout.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterSectionLayout.swift
@@ -1,0 +1,114 @@
+//
+//  ProductFilterSectionLayout.swift
+//  Pyonsnal-Color
+//
+//  Created by 김인호 on 2023/07/25.
+//
+
+import UIKit
+
+final class ProductFilterSectionLayout {
+    
+    enum Size {
+        static let sortCellHeight: CGFloat = 40
+        static let eventCellHeight: CGFloat = 40
+        static let categoryCellHeight: CGFloat = 108
+    }
+    
+    private func createSortSection() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1),
+            heightDimension: .fractionalHeight(1)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1),
+            heightDimension: .estimated(Size.sortCellHeight)
+        )
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        group.interItemSpacing = .fixed(Spacing.spacing12.value)
+        
+        let section = NSCollectionLayoutSection(group: group)
+        return section
+    }
+    
+    private func createEventSection() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(0.5),
+            heightDimension: .fractionalHeight(1)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1),
+            heightDimension: .estimated(Size.eventCellHeight)
+        )
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: groupSize,
+            subitem: item,
+            count: 2
+        )
+        group.interItemSpacing = .fixed(Spacing.spacing12.value)
+        
+        let section = NSCollectionLayoutSection(group: group)
+        return section
+    }
+    
+    private func createCategorySection() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(0.33),
+            heightDimension: .fractionalHeight(1)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1),
+            heightDimension: .estimated(Size.categoryCellHeight)
+        )
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: groupSize,
+            subitem: item,
+            count: 3
+        )
+        group.interItemSpacing = .fixed(Spacing.spacing24.value)
+        
+        let section = NSCollectionLayoutSection(group: group)
+        return section
+    }
+    
+    private func createRecommendationSection() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(0.33),
+            heightDimension: .fractionalHeight(1)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1),
+            heightDimension: .estimated(Size.categoryCellHeight)
+        )
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: groupSize,
+            subitem: item,
+            count: 3
+        )
+        group.interItemSpacing = .fixed(Spacing.spacing24.value)
+        
+        let section = NSCollectionLayoutSection(group: group)
+        return section
+    }
+}
+
+extension ProductFilterSectionLayout {
+    func section(at section: ProductFilterViewController.Section) -> NSCollectionLayoutSection {
+        switch section {
+        case .sort:
+            return createSortSection()
+        case .event:
+            return createEventSection()
+        case .category, .recommendation:
+            return createCategorySection()
+        }
+    }
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterSectionLayout.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterSectionLayout.swift
@@ -27,9 +27,9 @@ final class ProductFilterSectionLayout {
             heightDimension: .estimated(Size.sortCellHeight)
         )
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
-        group.interItemSpacing = .fixed(Spacing.spacing12.value)
         
         let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = Spacing.spacing12.value
         return section
     }
     

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterSectionLayout.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterSectionLayout.swift
@@ -103,14 +103,16 @@ final class ProductFilterSectionLayout {
 }
 
 extension ProductFilterSectionLayout {
-    func section(at section: ProductFilterViewController.Section) -> NSCollectionLayoutSection {
+    func section(at section: FilterType) -> NSCollectionLayoutSection? {
         switch section {
         case .sort:
             return createSortSection()
         case .event:
             return createEventSection()
-        case .category, .recommendation:
+        case .category, .recommend:
             return createCategorySection()
+        case .unknown:
+            return nil
         }
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterSectionLayout.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterSectionLayout.swift
@@ -29,7 +29,7 @@ final class ProductFilterSectionLayout {
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
         
         let section = NSCollectionLayoutSection(group: group)
-        section.interGroupSpacing = Spacing.spacing12.value
+        section.interGroupSpacing = .spacing12
         return section
     }
     
@@ -49,7 +49,7 @@ final class ProductFilterSectionLayout {
             subitem: item,
             count: 2
         )
-        group.interItemSpacing = .fixed(Spacing.spacing12.value)
+        group.interItemSpacing = .fixed(.spacing12)
         
         let section = NSCollectionLayoutSection(group: group)
         return section
@@ -94,7 +94,7 @@ final class ProductFilterSectionLayout {
             subitem: item,
             count: 3
         )
-        group.interItemSpacing = .fixed(Spacing.spacing24.value)
+        group.interItemSpacing = .fixed(.spacing24)
         
         let section = NSCollectionLayoutSection(group: group)
         return section

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterSectionLayout.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterSectionLayout.swift
@@ -71,9 +71,10 @@ final class ProductFilterSectionLayout {
             subitem: item,
             count: 3
         )
-        group.interItemSpacing = .fixed(Spacing.spacing24.value)
+        group.interItemSpacing = .fixed(.spacing24)
         
         let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = .spacing20
         return section
     }
     

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
@@ -79,12 +79,14 @@ final class ProductFilterViewController:
         case recommendation(title: String, selected: Bool)
     }
 
+    // MARK: - Property
     weak var listener: ProductFilterPresentableListener?
     
     private let viewHolder = ViewHolder()
     private var dataSource: DataSource?
     private let filterType: Section
     
+    // MARK: - Initializer
     init(filterType: Section) {
         self.filterType = filterType
         super.init(nibName: nil, bundle: nil)
@@ -94,6 +96,7 @@ final class ProductFilterViewController:
         fatalError("init(coder:) has not been implemented")
     }
     
+    // MARK: - Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -109,6 +112,7 @@ final class ProductFilterViewController:
         resizeCollectionViewHeight()
     }
     
+    // MARK: - Private Method
     private func configureView() {
         view.backgroundColor = .black.withAlphaComponent(0.7)
         setFilterTitle()
@@ -236,6 +240,7 @@ final class ProductFilterViewController:
         }
     }
     
+    // MARK: - Objective Method
     @objc private func didTapApplyButton() {
         listener?.didTapApplyButton(with: [])
     }
@@ -245,6 +250,7 @@ final class ProductFilterViewController:
     }
 }
 
+// MARK: - UICollectionViewDelegate
 extension ProductFilterViewController: UICollectionViewDelegate {
     func collectionView(
         _ collectionView: UICollectionView,

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
@@ -33,6 +33,13 @@ final class ProductFilterViewController:
         static let twoPlusOne = "2+1"
         static let discount = "할인"
         static let giftItem = "증정"
+        
+        static let food = "식품"
+        static let bakery = "베이커리"
+        static let snack = "과자류"
+        static let beverage = "음료"
+        static let iceCream = "아이스크림"
+        static let dailyGoods = "생활용품"
     }
     
     enum Section: Hashable {
@@ -45,15 +52,15 @@ final class ProductFilterViewController:
     enum Item: Hashable {
         case sort(title: String, selected: Bool)
         case event(title: String, selected: Bool)
-        case category
-        case recommendation
+        case category(title: String, selected: Bool)
+        case recommendation(title: String, selected: Bool)
     }
 
     weak var listener: ProductFilterPresentableListener?
     
     private let viewHolder = ViewHolder()
     private var dataSource: DataSource?
-    private let filterType: Section = .event
+    private let filterType: Section = .category
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -85,8 +92,10 @@ final class ProductFilterViewController:
             title = Text.sortTitle
         case .event:
             title = Text.eventTitle
-        default:
-            title = ""
+        case .category:
+            title = Text.categoryTitle
+        case .recommendation:
+            title = Text.recommendationTitle
         }
         
         viewHolder.titleLabel.text = title
@@ -115,6 +124,7 @@ final class ProductFilterViewController:
     private func registerCells() {
         viewHolder.collectionView.register(SortFilterCell.self)
         viewHolder.collectionView.register(EventFilterCell.self)
+        viewHolder.collectionView.register(CategoryFilterCell.self)
     }
     
     private func configureDataSource() {
@@ -130,8 +140,10 @@ final class ProductFilterViewController:
                 let cell: EventFilterCell = collectionView.dequeueReusableCell(for: index)
                 cell.configureCell(title: title, isSelected: isSelected)
                 return cell
-            default:
-                return UICollectionViewCell()
+            case let .category(title, isSelected), let .recommendation(title, isSelected):
+                let cell: CategoryFilterCell = collectionView.dequeueReusableCell(for: index)
+                cell.configureCell(title: title, isSelected: isSelected)
+                return cell
             }
         }
     }
@@ -141,10 +153,12 @@ final class ProductFilterViewController:
         var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
         snapshot.appendSections([filterType])
         snapshot.appendItems([
-            .event(title: Text.onePlusOne, selected: true),
-            .event(title: Text.twoPlusOne, selected: true),
-            .event(title: Text.discount, selected: false),
-            .event(title: Text.giftItem, selected: false)
+            .category(title: Text.food, selected: true),
+            .category(title: Text.bakery, selected: true),
+            .category(title: Text.snack, selected: false),
+            .category(title: Text.beverage, selected: false),
+            .category(title: Text.iceCream, selected: false),
+            .category(title: Text.dailyGoods, selected: false)
         ])
         
         dataSource?.apply(snapshot, animatingDifferences: true)

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
@@ -17,16 +17,34 @@ protocol ProductFilterPresentableListener: AnyObject {
 
 final class ProductFilterViewController: UIViewController, ProductFilterPresentable, ProductFilterViewControllable {
     
+    typealias DataSource = UICollectionViewDiffableDataSource<Section, Item>
+    
     enum Text {
         static let sortTitle = "정렬 선택"
         static let eventTitle = "행사"
         static let categoryTitle = "카테고리"
         static let recommendationTitle = "상품추천"
     }
+    
+    enum Section: Hashable {
+        case sort
+        case event
+        case category
+        case recommendation
+    }
+    
+    enum Item: Hashable {
+        case sort
+        case event
+        case category
+        case recommendation
+    }
 
     weak var listener: ProductFilterPresentableListener?
     
     private let viewHolder = ViewHolder()
+    private var dataSource: DataSource?
+    private let filterType: Section = .sort
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -41,11 +59,12 @@ final class ProductFilterViewController: UIViewController, ProductFilterPresenta
     }
     
     private func configureCollectionView() {
-        
+        viewHolder.collectionView.setCollectionViewLayout(createLayout(), animated: true)
     }
     
-    private func createLayout() {
-        
+    private func createLayout() -> UICollectionViewLayout {
+        let section = ProductFilterSectionLayout().section(at: filterType)
+        return  UICollectionViewCompositionalLayout(section: section)
     }
 }
 

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
@@ -174,7 +174,7 @@ final class ProductFilterViewController:
     private func registerCells() {
         viewHolder.collectionView.register(SortFilterCell.self)
         viewHolder.collectionView.register(EventFilterCell.self)
-        viewHolder.collectionView.register(CategoryFilterCell.self)
+        viewHolder.collectionView.register(RecommendFilterCell.self)
     }
     
     private func configureDataSource() {
@@ -191,7 +191,7 @@ final class ProductFilterViewController:
                 cell.configureCell(title: title, isSelected: isSelected)
                 return cell
             case let .category(title, isSelected), let .recommendation(title, isSelected):
-                let cell: CategoryFilterCell = collectionView.dequeueReusableCell(for: index)
+                let cell: RecommendFilterCell = collectionView.dequeueReusableCell(for: index)
                 cell.configureCell(title: title, isSelected: isSelected)
                 return cell
             }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
@@ -12,6 +12,7 @@ import SnapKit
 protocol ProductFilterPresentableListener: AnyObject {
     // TODO: 엔티티 변경
     func didTapApplyButton(with selectedItems: [FilterItemEntity])
+    func didSelectSortFilter(type: FilterItemEntity)
     func didTapCloseButton()
 }
 
@@ -27,7 +28,7 @@ final class ProductFilterViewController:
     
     private let viewHolder = ViewHolder()
     private var dataSource: DataSource?
-    private let filterEntity: FilterEntity
+    private var filterEntity: FilterEntity
     
     // MARK: - Initializer
     init(filterEntity: FilterEntity) {
@@ -84,7 +85,6 @@ final class ProductFilterViewController:
             target: self,
             action: #selector(didTapBackgroundView)
         )
-//        gestureRecognizer.cancelsTouchesInView = false
         gestureRecognizer.delegate = self
         view.addGestureRecognizer(gestureRecognizer)
     }
@@ -224,7 +224,7 @@ extension ProductFilterViewController: UICollectionViewDelegate {
         setApplyButtonState()
         
         if filterEntity.filterType == .sort {
-            listener?.didTapCloseButton()
+            listener?.didSelectSortFilter(type: filterEntity.filterItem[indexPath.item])
         }
     }
     

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
@@ -78,7 +78,7 @@ final class ProductFilterViewController:
     }
     
     private func configureView() {
-        view.backgroundColor = .black.withAlphaComponent(0.5)
+        view.backgroundColor = .black.withAlphaComponent(0.7)
         setFilterTitle()
         setMultiSelect()
         hideApplyButton()
@@ -183,6 +183,8 @@ extension ProductFilterViewController {
         }
         
         enum Size {
+            static let containerViewRadius: CGFloat = 16
+            static let grabViewRadius: CGFloat = 2.5
             static let grabViewSize: CGSize = .init(width: 36, height: 5)
             static let grabViewTop: CGFloat = 5
             static let titleLeading: CGFloat = 20
@@ -194,7 +196,7 @@ extension ProductFilterViewController {
             let view = UIView()
             view.backgroundColor = .white
             view.makeRoundCorners(
-                cornerRadius: 16,
+                cornerRadius: Size.containerViewRadius,
                 maskedCorners: [.layerMaxXMinYCorner, .layerMinXMinYCorner]
             )
             return view
@@ -202,7 +204,7 @@ extension ProductFilterViewController {
         
         private let grabView: UIView = {
             let view = UIView()
-            view.makeRounded(with: 2.5)
+            view.makeRounded(with: Size.grabViewRadius)
             view.backgroundColor = .gray400
             return view
         }()
@@ -223,7 +225,7 @@ extension ProductFilterViewController {
         let stackView: UIStackView = {
             let stackView = UIStackView()
             stackView.axis = .vertical
-            stackView.spacing = Spacing.spacing40.value
+            stackView.spacing = .spacing40
             return stackView
         }()
         
@@ -266,8 +268,8 @@ extension ProductFilterViewController {
             }
             
             closeButton.snp.makeConstraints {
-                $0.top.equalToSuperview().offset(Spacing.spacing12.value)
-                $0.trailing.equalToSuperview().inset(Spacing.spacing12.value)
+                $0.top.equalToSuperview().offset(.spacing12)
+                $0.trailing.equalToSuperview().inset(.spacing12)
             }
             
             titleLabel.snp.makeConstraints {
@@ -278,14 +280,14 @@ extension ProductFilterViewController {
             stackView.snp.makeConstraints {
                 $0.leading.equalToSuperview().offset(Size.titleLeading)
                 $0.trailing.equalToSuperview().inset(Size.titleLeading)
-                $0.top.equalTo(titleLabel.snp.bottom).offset(Spacing.spacing24.value)
+                $0.top.equalTo(titleLabel.snp.bottom).offset(.spacing24)
             }
             
             collectionView.snp.makeConstraints {
                 $0.height.greaterThanOrEqualTo(90)
                 $0.bottom.lessThanOrEqualTo(
                     view.safeAreaLayoutGuide
-                ).inset(Spacing.spacing40.value).priority(.low)
+                ).inset(.spacing40).priority(.low)
             }
             
             applyButton.snp.makeConstraints {

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
@@ -80,7 +80,7 @@ final class ProductFilterViewController:
     
     private let viewHolder = ViewHolder()
     private var dataSource: DataSource?
-    private let filterType: Section = .sort
+    private let filterType: Section = .event
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -131,6 +131,7 @@ final class ProductFilterViewController:
     
     private func configureCollectionView() {
         viewHolder.collectionView.setCollectionViewLayout(createLayout(), animated: true)
+        viewHolder.collectionView.delegate = self
         registerCells()
         configureDataSource()
         applySnapshot()
@@ -172,7 +173,7 @@ final class ProductFilterViewController:
     private func applySnapshot() {
         var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
         snapshot.appendSections([filterType])
-        snapshot.appendItems(DummyData.Sort.allCases.map { .sort(
+        snapshot.appendItems(DummyData.Event.allCases.map { .event(
             title: $0.rawValue,
             selected: false
         ) })
@@ -188,6 +189,32 @@ final class ProductFilterViewController:
                 $0.height.equalTo(height)
             }
         }
+    }
+    
+    private func setApplyButtonState() {
+        guard filterType != .sort else { return }
+        
+        if viewHolder.collectionView.indexPathsForSelectedItems?.count == 0 {
+            viewHolder.applyButton.setState(with: .disabled)
+        } else {
+            viewHolder.applyButton.setState(with: .enabled)
+        }
+    }
+}
+
+extension ProductFilterViewController: UICollectionViewDelegate {
+    func collectionView(
+        _ collectionView: UICollectionView,
+        didSelectItemAt indexPath: IndexPath
+    ) {
+        setApplyButtonState()
+    }
+    
+    func collectionView(
+        _ collectionView: UICollectionView,
+        didDeselectItemAt indexPath: IndexPath
+    ) {
+        setApplyButtonState()
     }
 }
 

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
@@ -28,6 +28,11 @@ final class ProductFilterViewController:
         static let recent = "최신순"
         static let lowestPrice = "낮은 가격 순"
         static let highestPrice = "높은 가격 순"
+        
+        static let onePlusOne = "1+1"
+        static let twoPlusOne = "2+1"
+        static let discount = "할인"
+        static let giftItem = "증정"
     }
     
     enum Section: Hashable {
@@ -39,7 +44,7 @@ final class ProductFilterViewController:
     
     enum Item: Hashable {
         case sort(title: String, selected: Bool)
-        case event
+        case event(title: String, selected: Bool)
         case category
         case recommendation
     }
@@ -48,7 +53,7 @@ final class ProductFilterViewController:
     
     private let viewHolder = ViewHolder()
     private var dataSource: DataSource?
-    private let filterType: Section = .sort
+    private let filterType: Section = .event
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -67,17 +72,28 @@ final class ProductFilterViewController:
     
     private func configureView() {
         view.backgroundColor = .black.withAlphaComponent(0.5)
+        setFilterTitle()
+        setMultiSelect()
+        hideApplyButton()
+    }
+    
+    private func setFilterTitle() {
         let title: String
         
         switch filterType {
         case .sort:
             title = Text.sortTitle
+        case .event:
+            title = Text.eventTitle
         default:
             title = ""
         }
         
         viewHolder.titleLabel.text = title
-        hideApplyButton()
+    }
+    
+    private func setMultiSelect() {
+        viewHolder.collectionView.allowsMultipleSelection = filterType == .sort ? false : true
     }
     
     private func hideApplyButton() {
@@ -98,6 +114,7 @@ final class ProductFilterViewController:
     
     private func registerCells() {
         viewHolder.collectionView.register(SortFilterCell.self)
+        viewHolder.collectionView.register(EventFilterCell.self)
     }
     
     private func configureDataSource() {
@@ -109,6 +126,10 @@ final class ProductFilterViewController:
                 let cell: SortFilterCell = collectionView.dequeueReusableCell(for: index)
                 cell.configureCell(title: title, isSelected: isSelected)
                 return cell
+            case let .event(title, isSelected):
+                let cell: EventFilterCell = collectionView.dequeueReusableCell(for: index)
+                cell.configureCell(title: title, isSelected: isSelected)
+                return cell
             default:
                 return UICollectionViewCell()
             }
@@ -118,11 +139,12 @@ final class ProductFilterViewController:
     // TODO: 외부 데이터 받아오도록 수정
     private func applySnapshot() {
         var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
-        snapshot.appendSections([.sort])
+        snapshot.appendSections([filterType])
         snapshot.appendItems([
-            .sort(title: Text.recent, selected: true),
-            .sort(title: Text.lowestPrice, selected: false),
-            .sort(title: Text.highestPrice, selected: false)
+            .event(title: Text.onePlusOne, selected: true),
+            .event(title: Text.twoPlusOne, selected: true),
+            .event(title: Text.discount, selected: false),
+            .event(title: Text.giftItem, selected: false)
         ])
         
         dataSource?.apply(snapshot, animatingDifferences: true)

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
@@ -1,0 +1,147 @@
+//
+//  ProductFilterViewController.swift
+//  Pyonsnal-Color
+//
+//  Created by 김인호 on 2023/07/25.
+//
+
+import UIKit
+import ModernRIBs
+import SnapKit
+
+protocol ProductFilterPresentableListener: AnyObject {
+    // TODO: Declare properties and methods that the view controller can invoke to perform
+    // business logic, such as signIn(). This protocol is implemented by the corresponding
+    // interactor class.
+}
+
+final class ProductFilterViewController: UIViewController, ProductFilterPresentable, ProductFilterViewControllable {
+    
+    enum Text {
+        static let sortTitle = "정렬 선택"
+        static let eventTitle = "행사"
+        static let categoryTitle = "카테고리"
+        static let recommendationTitle = "상품추천"
+    }
+
+    weak var listener: ProductFilterPresentableListener?
+    
+    private let viewHolder = ViewHolder()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        viewHolder.place(in: view)
+        viewHolder.configureConstraints(for: view)
+        configureView()
+    }
+    
+    private func configureView() {
+        view.backgroundColor = .black.withAlphaComponent(0.5)
+    }
+    
+    private func configureCollectionView() {
+        
+    }
+    
+    private func createLayout() {
+        
+    }
+}
+
+extension ProductFilterViewController {
+    final class ViewHolder: ViewHolderable {
+        
+        enum Text {
+            static let applyTitle: String = "적용하기"
+        }
+        
+        enum Size {
+            static let grabViewSize: CGSize = .init(width: 36, height: 5)
+            static let grabViewTop: CGFloat = 5
+            static let titleLeading: CGFloat = 20
+            static let titleTop: CGFloat = 40
+        }
+        
+        private let containerView: UIView = {
+            let view = UIView()
+            view.backgroundColor = .white
+            view.makeRoundCorners(cornerRadius: 16, maskedCorners: .layerMinXMinYCorner)
+            view.makeRoundCorners(cornerRadius: 16, maskedCorners: .layerMaxXMinYCorner)
+            return view
+        }()
+        
+        private let grabView: UIView = {
+            let view = UIView()
+            view.makeRounded(with: 2.5)
+            view.backgroundColor = .gray200
+            return view
+        }()
+        
+        let closeButton: UIButton = {
+            let button = UIButton()
+            button.setImage(.iconClose, for: .normal)
+            return button
+        }()
+        
+        let titleLabel: UILabel = {
+            let label = UILabel()
+            label.font = .title1
+            label.textColor = .black
+            return label
+        }()
+        
+        let collectionView: UICollectionView = .init(frame: .zero)
+        
+        let applyButton: PrimaryButton = {
+            let button = PrimaryButton(state: .disabled)
+            button.setText(with: Text.applyTitle)
+            return button
+        }()
+        
+        func place(in view: UIView) {
+            view.addSubview(containerView)
+            
+            containerView.addSubview(grabView)
+            containerView.addSubview(closeButton)
+            containerView.addSubview(titleLabel)
+            containerView.addSubview(collectionView)
+            containerView.addSubview(applyButton)
+        }
+        
+        func configureConstraints(for view: UIView) {
+            containerView.snp.makeConstraints {
+                $0.leading.trailing.bottom.equalTo(view)
+            }
+            
+            grabView.snp.makeConstraints {
+                $0.centerX.equalToSuperview()
+                $0.top.equalTo(containerView.snp.bottom).offset(Size.grabViewTop)
+                $0.size.equalTo(Size.grabViewSize)
+            }
+            
+            closeButton.snp.makeConstraints {
+                $0.top.equalToSuperview().offset(Spacing.spacing12.value)
+                $0.trailing.equalToSuperview().inset(Spacing.spacing12.value)
+            }
+            
+            titleLabel.snp.makeConstraints {
+                $0.leading.equalToSuperview().offset(Size.titleLeading)
+                $0.top.equalToSuperview().offset(Size.titleTop)
+            }
+            
+            collectionView.snp.makeConstraints {
+                $0.leading.trailing.equalTo(applyButton)
+                $0.top.equalTo(titleLabel).offset(Spacing.spacing24.value)
+                $0.bottom.equalTo(applyButton).inset(Spacing.spacing40.value)
+            }
+            
+            applyButton.snp.makeConstraints {
+                $0.leading.equalTo(titleLabel)
+                $0.trailing.equalToSuperview().inset(Size.titleLeading)
+                $0.bottom.lessThanOrEqualTo(view.safeAreaLayoutGuide.snp.bottom)
+                $0.bottom.equalToSuperview().inset(.spacing16).priority(.low)
+            }
+        }
+    }
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
@@ -24,22 +24,42 @@ final class ProductFilterViewController:
         static let eventTitle = "행사"
         static let categoryTitle = "카테고리"
         static let recommendationTitle = "상품추천"
+    }
+    
+    enum DummyData {
         
-        static let recent = "최신순"
-        static let lowestPrice = "낮은 가격 순"
-        static let highestPrice = "높은 가격 순"
+        enum Sort: String, CaseIterable {
+            case recent = "최신순"
+            case lowestPrice = "낮은 가격 순"
+            case highestPrice = "높은 가격 순"
+        }
         
-        static let onePlusOne = "1+1"
-        static let twoPlusOne = "2+1"
-        static let discount = "할인"
-        static let giftItem = "증정"
+        enum Event: String, CaseIterable {
+            case onePlusOne = "1+1"
+            case twoPlusOne = "2+1"
+            case discount = "할인"
+            case giftItem = "증정"
+        }
         
-        static let food = "식품"
-        static let bakery = "베이커리"
-        static let snack = "과자류"
-        static let beverage = "음료"
-        static let iceCream = "아이스크림"
-        static let dailyGoods = "생활용품"
+        enum Category: String, CaseIterable {
+            case food = "식품"
+            case bakery = "베이커리"
+            case snack = "과자류"
+            case beverage = "음료"
+            case iceCream = "아이스크림"
+            case dailyGoods = "생활용품"
+        }
+        
+        enum Recommend: String, CaseIterable {
+            case food = "식품"
+            case bakery = "베이커리"
+            case snack = "과자류"
+            case beverage = "음료"
+            case iceCream = "아이스크림"
+            case dailyGoods = "생활용품"
+            case beer = "맥주"
+            case cigarette = "담배"
+        }
     }
     
     enum Section: Hashable {
@@ -60,7 +80,7 @@ final class ProductFilterViewController:
     
     private let viewHolder = ViewHolder()
     private var dataSource: DataSource?
-    private let filterType: Section = .category
+    private let filterType: Section = .sort
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -152,14 +172,10 @@ final class ProductFilterViewController:
     private func applySnapshot() {
         var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
         snapshot.appendSections([filterType])
-        snapshot.appendItems([
-            .category(title: Text.food, selected: true),
-            .category(title: Text.bakery, selected: true),
-            .category(title: Text.snack, selected: false),
-            .category(title: Text.beverage, selected: false),
-            .category(title: Text.iceCream, selected: false),
-            .category(title: Text.dailyGoods, selected: false)
-        ])
+        snapshot.appendItems(DummyData.Sort.allCases.map { .sort(
+            title: $0.rawValue,
+            selected: false
+        ) })
         
         dataSource?.apply(snapshot, animatingDifferences: true)
     }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
@@ -61,6 +61,7 @@ final class ProductFilterViewController:
         setFilterTitle()
         setMultiSelect()
         hideApplyButton()
+        configureButtonsAction()
     }
     
     private func setFilterTitle() {
@@ -114,14 +115,14 @@ final class ProductFilterViewController:
     private func configureDataSource() {
         dataSource = DataSource(
             collectionView: viewHolder.collectionView
-        ) { collectionView, index, item in
-            switch self.filterEntity.filterType {
+        ) { [weak self] collectionView, index, item in
+            switch self?.filterEntity.filterType {
             case .sort:
                 let cell: SortFilterCell = collectionView.dequeueReusableCell(for: index)
                 
                 cell.configureCell(filterItem: item)
                 if item.isSelected {
-                    self.setSelectedItemToCollectionView(at: index)
+                    self?.setSelectedItemToCollectionView(at: index)
                 }
                 return cell
             case .event:
@@ -129,7 +130,7 @@ final class ProductFilterViewController:
                 
                 cell.configureCell(filterItem: item)
                 if item.isSelected {
-                    self.setSelectedItemToCollectionView(at: index)
+                    self?.setSelectedItemToCollectionView(at: index)
                 }
                 return cell
             case .category, .recommend:
@@ -137,7 +138,7 @@ final class ProductFilterViewController:
                 
                 cell.configureCell(filterItem: item)
                 if item.isSelected {
-                    self.setSelectedItemToCollectionView(at: index)
+                    self?.setSelectedItemToCollectionView(at: index)
                 }
                 return cell
             default:

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
@@ -12,7 +12,10 @@ import SnapKit
 protocol ProductFilterPresentableListener: AnyObject {
 }
 
-final class ProductFilterViewController: UIViewController, ProductFilterPresentable, ProductFilterViewControllable {
+final class ProductFilterViewController:
+    UIViewController,
+    ProductFilterPresentable,
+    ProductFilterViewControllable {
     
     typealias DataSource = UICollectionViewDiffableDataSource<Section, Item>
     
@@ -21,6 +24,10 @@ final class ProductFilterViewController: UIViewController, ProductFilterPresenta
         static let eventTitle = "행사"
         static let categoryTitle = "카테고리"
         static let recommendationTitle = "상품추천"
+        
+        static let recent = "최신순"
+        static let lowestPrice = "낮은 가격 순"
+        static let highestPrice = "높은 가격 순"
     }
     
     enum Section: Hashable {
@@ -31,7 +38,7 @@ final class ProductFilterViewController: UIViewController, ProductFilterPresenta
     }
     
     enum Item: Hashable {
-        case sort(index: Int)
+        case sort(title: String, selected: Bool)
         case event
         case category
         case recommendation
@@ -98,9 +105,9 @@ final class ProductFilterViewController: UIViewController, ProductFilterPresenta
             collectionView: viewHolder.collectionView
         ) { collectionView, index, item in
             switch item {
-            case .sort:
+            case let .sort(title, isSelected):
                 let cell: SortFilterCell = collectionView.dequeueReusableCell(for: index)
-                cell.configureCell(at: index.item)
+                cell.configureCell(title: title, isSelected: isSelected)
                 return cell
             default:
                 return UICollectionViewCell()
@@ -108,10 +115,15 @@ final class ProductFilterViewController: UIViewController, ProductFilterPresenta
         }
     }
     
+    // TODO: 외부 데이터 받아오도록 수정
     private func applySnapshot() {
         var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
         snapshot.appendSections([.sort])
-        snapshot.appendItems([.sort(index: 1), .sort(index: 2), .sort(index: 3)])
+        snapshot.appendItems([
+            .sort(title: Text.recent, selected: true),
+            .sort(title: Text.lowestPrice, selected: false),
+            .sort(title: Text.highestPrice, selected: false)
+        ])
         
         dataSource?.apply(snapshot, animatingDifferences: true)
     }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeBuilder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeBuilder.swift
@@ -12,9 +12,10 @@ protocol ProductHomeDependency: Dependency {
 }
 
 final class ProductHomeComponent: Component<ProductHomeDependency>,
-                                    ProductSearchDependency,
-                                    NotificationListDependency,
-                                  ProductDetailDependency {
+                                  ProductSearchDependency,
+                                  NotificationListDependency,
+                                  ProductDetailDependency,
+                                  ProductFilterDependency {
     let productAPIService: ProductAPIService
     
     override init(dependency: ProductHomeDependency) {
@@ -46,6 +47,7 @@ final class ProductHomeBuilder: Builder<ProductHomeDependency>, ProductHomeBuild
         let productSearch: ProductSearchBuilder = .init(dependency: component)
         let notificationList: NotificationListBuilder = .init(dependency: component)
         let productDetail: ProductDetailBuilder = .init(dependency: component)
+        let productFilter: ProductFilterBuilder = .init(dependency: component)
         
         interactor.listener = listener
         return ProductHomeRouter(
@@ -53,7 +55,8 @@ final class ProductHomeBuilder: Builder<ProductHomeDependency>, ProductHomeBuild
             viewController: viewController,
             productSearch: productSearch,
             notificationList: notificationList,
-            productDetail: productDetail
+            productDetail: productDetail,
+            productFilter: productFilter
         )
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeInteractor.swift
@@ -25,6 +25,7 @@ protocol ProductHomePresentable: Presentable {
     func updateProducts(with products: [ConvenienceStore: [BrandProductEntity]])
     func updateProducts(with products: [BrandProductEntity], at store: ConvenienceStore)
     func didFinishPaging()
+    func updateFilterItems(with items: [FilterItemEntity])
 }
 
 protocol ProductHomeListener: AnyObject {
@@ -143,5 +144,10 @@ final class ProductHomeInteractor:
     
     func productFilterDidTapCloseButton() {
         router?.detachProductFilter()
+    }
+    
+    func applyFilterItems(_ items: [FilterItemEntity]) {
+        router?.detachProductFilter()
+        presenter.updateFilterItems(with: items)
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeInteractor.swift
@@ -15,6 +15,8 @@ protocol ProductHomeRouting: ViewableRouting {
     func detachNotificationList()
     func attachProductDetail(with brandProduct: ProductConvertable)
     func detachProductDetail()
+    func attachProductFilter(of filter: FilterEntity)
+    func detachProductFilter()
 }
 
 protocol ProductHomePresentable: Presentable {
@@ -43,6 +45,7 @@ final class ProductHomeInteractor:
     private let productPerPage: Int = 20
     private var storeLastPages: [ConvenienceStore: Int] = [:]
     private var brandProducts: [ConvenienceStore: [BrandProductEntity]] = [:]
+    private var filterEntity: [FilterEntity] = []
 
     init(
         presenter: ProductHomePresentable,
@@ -130,5 +133,15 @@ final class ProductHomeInteractor:
     
     func didChangeStore(to store: ConvenienceStore) {
         requestInitialProducts(store: store)
+    }
+    
+    func didSelectFilter(ofType filterEntity: FilterEntity?) {
+        guard let filterEntity else { return }
+        
+        router?.attachProductFilter(of: filterEntity)
+    }
+    
+    func productFilterDidTapCloseButton() {
+        router?.detachProductFilter()
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeInteractor.swift
@@ -26,6 +26,7 @@ protocol ProductHomePresentable: Presentable {
     func updateProducts(with products: [BrandProductEntity], at store: ConvenienceStore)
     func didFinishPaging()
     func updateFilterItems(with items: [FilterItemEntity])
+    func updateSortFilter(type: FilterItemEntity)
 }
 
 protocol ProductHomeListener: AnyObject {
@@ -147,7 +148,14 @@ final class ProductHomeInteractor:
     }
     
     func applyFilterItems(_ items: [FilterItemEntity]) {
+        // TODO: 적용된 필터로 상품 목록 조회하기
         router?.detachProductFilter()
         presenter.updateFilterItems(with: items)
+    }
+    
+    func applySortFilter(type: FilterItemEntity) {
+        // TODO: 적용된 필터로 상품 목록 조회하기
+        router?.detachProductFilter()
+        presenter.updateSortFilter(type: type)
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeRouter.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeRouter.swift
@@ -7,7 +7,7 @@
 
 import ModernRIBs
 
-protocol ProductHomeInteractable: Interactable, ProductSearchListener, NotificationListListener, ProductDetailListener {
+protocol ProductHomeInteractable: Interactable, ProductSearchListener, NotificationListListener, ProductDetailListener, ProductFilterListener {
     var router: ProductHomeRouting? { get set }
     var listener: ProductHomeListener? { get set }
 }
@@ -22,21 +22,25 @@ final class ProductHomeRouter:
     private let productSearch: ProductSearchBuildable
     private let notificationList: NotificationListBuildable
     private let productDetail: ProductDetailBuildable
+    private let productFilter: ProductFilterBuildable
     
     private var productSearchRouting: ProductSearchRouting?
     private var notificationListRouting: NotificationListRouting?
     private var productDetailRouting: ProductDetailRouting?
+    private var productFilterRouting: ProductFilterRouting?
     
     init(
         interactor: ProductHomeInteractable,
         viewController: ProductHomeViewControllable,
         productSearch: ProductSearchBuildable,
         notificationList: NotificationListBuildable,
-        productDetail: ProductDetailBuildable
+        productDetail: ProductDetailBuildable,
+        productFilter: ProductFilterBuildable
     ) {
         self.productSearch = productSearch
         self.notificationList = notificationList
         self.productDetail = productDetail
+        self.productFilter = productFilter
         super.init(interactor: interactor, viewController: viewController)
         
         interactor.router = self
@@ -104,5 +108,29 @@ final class ProductHomeRouter:
         viewController.popViewController(animated: true)
         self.productDetailRouting = nil
         detachChild(productDetailRouting)
+    }
+    
+    func attachProductFilter(of filter: FilterEntity) {
+        guard productFilterRouting == nil else { return }
+        
+        let productFilterRouter = productFilter.build(
+            withListener: interactor,
+            filterEntity: filter
+        )
+        let productFilterViewController = productFilterRouter.viewControllable.uiviewController
+        productFilterViewController.modalPresentationStyle = .overFullScreen
+        productFilterRouting = productFilterRouter
+        attachChild(productFilterRouter)
+        viewControllable.uiviewController.present(
+            productFilterViewController,
+            animated: true
+        )
+    }
+    
+    func detachProductFilter() {
+        guard let productFilterRouting else { return }
+        viewController.uiviewController.dismiss(animated: true)
+        self.productFilterRouting = nil
+        detachChild(productFilterRouting)
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeViewController.swift
@@ -81,8 +81,10 @@ final class ProductHomeViewController:
                     let cell: RefreshFilterCell = collectionView.dequeueReusableCell(for: indexPath)
                     return cell
                 case .category:
+                    guard let title = filterItem.filter?.defaultText else { return nil }
+                    
                     let cell: CategoryFilterCell = collectionView.dequeueReusableCell(for: indexPath)
-                    cell.configure(with: filterItem.filter?.defaultText ?? "", filterItem: [])
+                    cell.configure(with: title, filterItem: [])
                     return cell
                 }
             }
@@ -118,12 +120,7 @@ final class ProductHomeViewController:
         dataSource?.apply(snapshot, animatingDifferences: true)
     }
     
-    private func setSortFilterDefaultText() {
-//        FilterDummy.data.data.first(where: { $0.filterType == .sort })?.defaultText = "정렬"
-    }
-    
     func makeFilterCellItem() -> [FilterCellItem] {
-        setSortFilterDefaultText()
         return FilterDummy.data.data.map { FilterCellItem(filter: $0) }
     }
     

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeViewController.swift
@@ -14,6 +14,7 @@ protocol ProductHomePresentableListener: AnyObject {
     func didTapNotificationButton()
     func didScrollToNextPage(store: ConvenienceStore)
     func didSelect(with brandProduct: ProductConvertable)
+    func didSelectFilter(ofType filterEntity: FilterEntity?)
 }
 
 final class ProductHomeViewController:
@@ -81,7 +82,7 @@ final class ProductHomeViewController:
                     return cell
                 case .category:
                     let cell: CategoryFilterCell = collectionView.dequeueReusableCell(for: indexPath)
-                    cell.configure(with: filterItem.defaultText, filterItem: [])
+                    cell.configure(with: filterItem.filter?.defaultText ?? "", filterItem: [])
                     return cell
                 }
             }
@@ -123,9 +124,7 @@ final class ProductHomeViewController:
     
     func makeFilterCellItem() -> [FilterCellItem] {
         setSortFilterDefaultText()
-        return FilterDummy.data.data.map { $0.defaultText }.map { defaultText in
-            FilterCellItem(defaultText: defaultText)
-        }
+        return FilterDummy.data.data.map { FilterCellItem(filter: $0) }
     }
     
     private func setSelectedConvenienceStoreCell(with indexPath: IndexPath) {
@@ -315,12 +314,19 @@ extension ProductHomeViewController: UIScrollViewDelegate {
 extension ProductHomeViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if collectionView == viewHolder.collectionView {
-            currentPage = indexPath.item
-            viewHolder.productHomePageViewController.updatePage(to: currentPage)
-        } else {
+            guard let selectedItem = dataSource?.itemIdentifier(for: indexPath) else { return }
             
+            switch selectedItem {
+            case .convenienceStore:
+                currentPage = indexPath.item
+                viewHolder.productHomePageViewController.updatePage(to: currentPage)
+            case .filter(let filterItem):
+                listener?.didSelectFilter(ofType: filterItem.filter)
+            }
+        } else {
             guard let productListViewController =  viewHolder.productHomePageViewController.viewControllers?.first as? ProductListViewController,
             let selectedItem = productListViewController.dataSource?.itemIdentifier(for: indexPath) else { return }
+            
             switch selectedItem {
             case .keywordFilter(let keywordFilter):
                 print("TO DO")

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeViewController.swift
@@ -234,6 +234,11 @@ final class ProductHomeViewController:
     func didFinishPaging() {
         isPaging = false
     }
+    
+    func updateFilterItems(with items: [FilterItemEntity]) {
+        // TODO: 추가된 필터들 적용
+        print(items)
+    }
 }
 
 // MARK: - TitleNavigationViewDelegate {

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeViewController.swift
@@ -119,7 +119,7 @@ final class ProductHomeViewController:
     }
     
     private func setSortFilterDefaultText() {
-        FilterDummy.data.data.first(where: { $0.filterType == .sort })?.defaultText = "정렬"
+//        FilterDummy.data.data.first(where: { $0.filterType == .sort })?.defaultText = "정렬"
     }
     
     func makeFilterCellItem() -> [FilterCellItem] {
@@ -238,6 +238,21 @@ final class ProductHomeViewController:
     func updateFilterItems(with items: [FilterItemEntity]) {
         // TODO: 추가된 필터들 적용
         print(items)
+    }
+    
+    func updateSortFilter(type: FilterItemEntity) {
+        guard var snapshot = dataSource?.snapshot(for: .filter) else { return }
+        let sortFilterIndex = 1, resetButtonIndex = 0
+        let currentItem = snapshot.items[sortFilterIndex]
+        let beforeItem = snapshot.items[resetButtonIndex]
+        
+        if case var .filter(item) = currentItem {
+            item.filter?.defaultText = type.name
+            snapshot.delete([currentItem])
+            snapshot.insert([.filter(filterItem: item)], after: beforeItem)
+            
+            dataSource?.apply(snapshot, to: .filter)
+        }
     }
 }
 

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeViewHolder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeViewHolder.swift
@@ -43,7 +43,6 @@ extension ProductHomeViewController {
             let layout = UICollectionViewFlowLayout()
             let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
             collectionView.backgroundColor = .clear
-            collectionView.isScrollEnabled = false
             collectionView.layoutMargins = UIEdgeInsets(
                 top: 0,
                 left: Constant.Size.leftRightMargin,

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeViewHolder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeViewHolder.swift
@@ -92,7 +92,7 @@ extension ProductHomeViewController {
             collectionView.snp.makeConstraints { make in
                 make.top.equalTo(titleNavigationView.snp.bottom)
                 make.leading.trailing.equalToSuperview().inset(.spacing16)
-                let height = TopCommonSectionLayout.ConvenienceStore.height + TopCommonSectionLayout.CategoryFilter.height
+                let height = TopCommonSectionLayout.ConvenienceStore.height + TopCommonSectionLayout.Filter.height
                 make.height.equalTo(height)
             }
             

--- a/Pyonsnal-Color/Pyonsnal-Color/Resource/Assets.xcassets/Common/check.selected.red.imageset/Contents.json
+++ b/Pyonsnal-Color/Pyonsnal-Color/Resource/Assets.xcassets/Common/check.selected.red.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "icon_check_selected.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/Resource/Assets.xcassets/Common/check.selected.red.imageset/icon_check_selected.svg
+++ b/Pyonsnal-Color/Pyonsnal-Color/Resource/Assets.xcassets/Common/check.selected.red.imageset/icon_check_selected.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="10" fill="#FF625F"/>
+<path d="M16.668 8.66671L10.0013 15.3334L7.33464 12.6667" stroke="white" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/Pyonsnal-Color/Pyonsnal-Color/Resource/ImageAssetKind/ImageAssetKind.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Resource/ImageAssetKind/ImageAssetKind.swift
@@ -28,7 +28,9 @@ enum ImageAssetKind: String {
     case iconClose = "icon_close"
     case check = "check"
     case checkSelected = "check.selected"
+    case checkSelectedRed = "check.selected.red"
     case iconArrow = "icon_arrow"
+    case iconCheck = "icon_check"
 }
 
 extension ImageAssetKind {


### PR DESCRIPTION
### 이슈
#98 

### 수정사항
#### 필터 선택시 보여지는 바텀시트 구현입니다.
- 정렬 필터는 `multi select가 안되어` 셀 하나 선택시 바로 적용됩니다.
- `multi select`가 가능한 카테고리들은 한개 이상의 셀을 눌러야 적용 버튼이 활성화 됩니다.
- `회색 배경 & X 버튼 누를 시` 필터가 적용되지 않고 바텀시트가 `dismiss`됩니다.
> 현재는 dummyData로 정보를 보여주고 적용하기 버튼 누를 시 상위 리블렛에게 전달하는 플로우를 구현하였고 dummyData를 가공하지는 않습니다.

#### 추가되어야 할 것
- 라디오 버튼(행사 필터 선택시)의 체크 마크의 비율이 제대로 잡히지 않아 수정할 예정입니다.
- 바텀시트 상단의 회색 바를 이용해 화면을 dismiss하는 기능을 추가할 예정입니다.

### 스크린샷
<img src="https://github.com/YAPP-Github/PyonsnalColor-iOS/assets/71054048/b9e18bc3-6bf1-4ace-b69b-9a1025563835" width=300>
