### PR TITLE
차별화 상품 & 이벤트 탭의 delegate 구조 통일

### DIFF
--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeViewController.swift
@@ -567,6 +567,10 @@ extension ProductHomeViewController: ProductHomePageViewControllerDelegate {
         setSelectedConvenienceStoreCell(with: indexPath)
         applyFilterSnapshot(with: currentListViewController()?.getFilterDataEntity())
     }
+    
+    func curationWillAppear() {
+        hideFilterCollectionView()
+    }
 }
 
 // MARK: - ProductPresentable
@@ -597,12 +601,5 @@ extension ProductHomeViewController: RefreshFilterCellDelegate {
         // apply filterData
         let filterDataEntity = listViewController.getFilterDataEntity()
         applyFilterSnapshot(with: filterDataEntity)
-    }
-}
-
-// MARK: - CurationDelegate
-extension ProductHomeViewController: CurationDelegate {
-    func curationWillAppear() {
-        hideFilterCollectionView()
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/Views/ProductHomePageViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/Views/ProductHomePageViewController.swift
@@ -18,6 +18,7 @@ protocol ProductHomePageViewControllerDelegate: AnyObject {
     func refreshFilterButton()
     func didFinishUpdateSnapshot()
     func didAppearProductList()
+    func curationWillAppear()
 }
 
 final class ProductHomePageViewController: UIPageViewController {
@@ -38,6 +39,7 @@ final class ProductHomePageViewController: UIPageViewController {
     // MARK: - Private Method
     private func generateChildViewControllers() {
         let curationViewController = ProductCurationViewController()
+        curationViewController.curationDelegate = self
         curationViewController.delegate = self
         productListViewControllers.append(curationViewController)
         
@@ -187,5 +189,12 @@ extension ProductHomePageViewController: ProductListDelegate {
     
     func didFinishUpdateSnapshot() {
         pagingDelegate?.didFinishUpdateSnapshot()
+    }
+}
+
+// MARK: - CurationDelegate
+extension ProductHomePageViewController: CurationDelegate {
+    func curationWillAppear() {
+        pagingDelegate?.curationWillAppear()
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/Views/ProductHomePageViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/Views/ProductHomePageViewController.swift
@@ -17,6 +17,7 @@ protocol ProductHomePageViewControllerDelegate: AnyObject {
     func deleteFilterItem(with filter: FilterItemEntity, isSelected: Bool)
     func refreshFilterButton()
     func didFinishUpdateSnapshot()
+    func didAppearProductList()
 }
 
 final class ProductHomePageViewController: UIPageViewController {
@@ -180,6 +181,7 @@ extension ProductHomePageViewController: ProductListDelegate {
     }
     
     func didAppearProductList() {
+        pagingDelegate?.didAppearProductList()
     }
     
     func didFinishUpdateSnapshot() {

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/Views/ProductHomePageViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/Views/ProductHomePageViewController.swift
@@ -38,6 +38,7 @@ final class ProductHomePageViewController: UIPageViewController {
     // MARK: - Private Method
     private func generateChildViewControllers() {
         let curationViewController = ProductCurationViewController()
+        curationViewController.delegate = self
         productListViewControllers.append(curationViewController)
         
         ConvenienceStore.allCases.filter({ $0 != .all }).forEach {


### PR DESCRIPTION
### 수정사항
**차별화 상품** 탭의 `productHomeViewController` - `productHomePageViewController` - `productListViewController` 구조에서 delegate 전달 방식을 이벤트 탭과 같은 구조로 수정하였습니다~ 
(스크롤, 상품 선택, 필터 선택 관련)