### PR TITLE
Add: CombineCocoa 관련 extension 파일 추가

### DIFF
--- a/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
+++ b/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
@@ -231,6 +231,8 @@
 		F0E915AC2AA87913000919DA /* CombineCocoa+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E915AB2AA87913000919DA /* CombineCocoa+.swift */; };
 		F0E915AF2AA87B97000919DA /* ControlPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E915AE2AA87B97000919DA /* ControlPublisher.swift */; };
 		F0E915B12AA87BB4000919DA /* ControlSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E915B02AA87BB4000919DA /* ControlSubscription.swift */; };
+		F0E915B32AA8C28E000919DA /* GesturePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E915B22AA8C28E000919DA /* GesturePublisher.swift */; };
+		F0E915B52AA8C38C000919DA /* GestureSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E915B42AA8C38C000919DA /* GestureSubscription.swift */; };
 		F0EE10A12A4B122A00B8DF4F /* UITableView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EE10A02A4B122A00B8DF4F /* UITableView+.swift */; };
 		F0EE10A32A4B242C00B8DF4F /* ProfileCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EE10A22A4B242C00B8DF4F /* ProfileCell.swift */; };
 		F0EE10A52A4B2E5200B8DF4F /* AppInfoService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EE10A42A4B2E5200B8DF4F /* AppInfoService.swift */; };
@@ -457,6 +459,8 @@
 		F0E915AB2AA87913000919DA /* CombineCocoa+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CombineCocoa+.swift"; sourceTree = "<group>"; };
 		F0E915AE2AA87B97000919DA /* ControlPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPublisher.swift; sourceTree = "<group>"; };
 		F0E915B02AA87BB4000919DA /* ControlSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlSubscription.swift; sourceTree = "<group>"; };
+		F0E915B22AA8C28E000919DA /* GesturePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GesturePublisher.swift; sourceTree = "<group>"; };
+		F0E915B42AA8C38C000919DA /* GestureSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GestureSubscription.swift; sourceTree = "<group>"; };
 		F0EE10A02A4B122A00B8DF4F /* UITableView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+.swift"; sourceTree = "<group>"; };
 		F0EE10A22A4B242C00B8DF4F /* ProfileCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCell.swift; sourceTree = "<group>"; };
 		F0EE10A42A4B2E5200B8DF4F /* AppInfoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfoService.swift; sourceTree = "<group>"; };
@@ -1225,6 +1229,8 @@
 			children = (
 				F0E915AE2AA87B97000919DA /* ControlPublisher.swift */,
 				F0E915B02AA87BB4000919DA /* ControlSubscription.swift */,
+				F0E915B22AA8C28E000919DA /* GesturePublisher.swift */,
+				F0E915B42AA8C38C000919DA /* GestureSubscription.swift */,
 			);
 			path = Combine;
 			sourceTree = "<group>";
@@ -1419,6 +1425,7 @@
 				F0E915AF2AA87B97000919DA /* ControlPublisher.swift in Sources */,
 				F0EE10A32A4B242C00B8DF4F /* ProfileCell.swift in Sources */,
 				B24F1D362A43E5B500AA03DC /* ProductListViewController.swift in Sources */,
+				F0E915B52AA8C38C000919DA /* GestureSubscription.swift in Sources */,
 				B28A59172A6E995500431F39 /* CurationEntity.swift in Sources */,
 				F0D6FFAD2A39F97900C55E27 /* String+.swift in Sources */,
 				BA18C0A62A7596F5007D00BD /* BottomToTopPresentAnimator.swift in Sources */,
@@ -1528,6 +1535,7 @@
 				BA87E3DE2A4629B5000A9DEC /* EventProductEntity.swift in Sources */,
 				B28A59302A739D3500431F39 /* EventFilterCell.swift in Sources */,
 				BAED882F2A24C3E600DA6257 /* RootRouter.swift in Sources */,
+				F0E915B32AA8C28E000919DA /* GesturePublisher.swift in Sources */,
 				B2A5294B2A57F2220010656A /* LogoutPopupBuilder.swift in Sources */,
 				BA87E3D52A45D400000A9DEC /* GiftItemView.swift in Sources */,
 				B24259052A590FCF006C5223 /* BrandProductEntity.swift in Sources */,

--- a/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
+++ b/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
@@ -227,6 +227,10 @@
 		F0DFBC962A59622A003F7660 /* MemberAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DFBC952A59622A003F7660 /* MemberAPIService.swift */; };
 		F0DFBC982A5966CD003F7660 /* EmptyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DFBC972A5966CD003F7660 /* EmptyResponse.swift */; };
 		F0DFBC9F2A596953003F7660 /* MemberInfoEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DFBC9E2A596953003F7660 /* MemberInfoEntity.swift */; };
+		F0E915AA2AA8711B000919DA /* UIControl+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E915A92AA8711B000919DA /* UIControl+.swift */; };
+		F0E915AC2AA87913000919DA /* CombineCocoa+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E915AB2AA87913000919DA /* CombineCocoa+.swift */; };
+		F0E915AF2AA87B97000919DA /* ControlPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E915AE2AA87B97000919DA /* ControlPublisher.swift */; };
+		F0E915B12AA87BB4000919DA /* ControlSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E915B02AA87BB4000919DA /* ControlSubscription.swift */; };
 		F0EE10A12A4B122A00B8DF4F /* UITableView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EE10A02A4B122A00B8DF4F /* UITableView+.swift */; };
 		F0EE10A32A4B242C00B8DF4F /* ProfileCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EE10A22A4B242C00B8DF4F /* ProfileCell.swift */; };
 		F0EE10A52A4B2E5200B8DF4F /* AppInfoService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EE10A42A4B2E5200B8DF4F /* AppInfoService.swift */; };
@@ -449,6 +453,10 @@
 		F0DFBC952A59622A003F7660 /* MemberAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberAPIService.swift; sourceTree = "<group>"; };
 		F0DFBC972A5966CD003F7660 /* EmptyResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyResponse.swift; sourceTree = "<group>"; };
 		F0DFBC9E2A596953003F7660 /* MemberInfoEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberInfoEntity.swift; sourceTree = "<group>"; };
+		F0E915A92AA8711B000919DA /* UIControl+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIControl+.swift"; sourceTree = "<group>"; };
+		F0E915AB2AA87913000919DA /* CombineCocoa+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CombineCocoa+.swift"; sourceTree = "<group>"; };
+		F0E915AE2AA87B97000919DA /* ControlPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPublisher.swift; sourceTree = "<group>"; };
+		F0E915B02AA87BB4000919DA /* ControlSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlSubscription.swift; sourceTree = "<group>"; };
 		F0EE10A02A4B122A00B8DF4F /* UITableView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+.swift"; sourceTree = "<group>"; };
 		F0EE10A22A4B242C00B8DF4F /* ProfileCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCell.swift; sourceTree = "<group>"; };
 		F0EE10A42A4B2E5200B8DF4F /* AppInfoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfoService.swift; sourceTree = "<group>"; };
@@ -721,6 +729,8 @@
 				B24F1D4F2A4EC72200AA03DC /* DateFormatter+.swift */,
 				F0EE10A02A4B122A00B8DF4F /* UITableView+.swift */,
 				BA00B7352A46B83A00BB3795 /* CGFloat+.swift */,
+				F0E915A92AA8711B000919DA /* UIControl+.swift */,
+				F0E915AB2AA87913000919DA /* CombineCocoa+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -960,6 +970,7 @@
 		BAEA1BFB2A3477A80028A90A /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				F0E915AD2AA87B86000919DA /* Combine */,
 				BA18C09E2A758F39007D00BD /* BottomSheet */,
 				F0C698742A6D4E980019C677 /* Protocol */,
 				F0C698712A6D4D8B0019C677 /* Layout */,
@@ -1209,6 +1220,15 @@
 			path = Member;
 			sourceTree = "<group>";
 		};
+		F0E915AD2AA87B86000919DA /* Combine */ = {
+			isa = PBXGroup;
+			children = (
+				F0E915AE2AA87B97000919DA /* ControlPublisher.swift */,
+				F0E915B02AA87BB4000919DA /* ControlSubscription.swift */,
+			);
+			path = Combine;
+			sourceTree = "<group>";
+		};
 		F0EE10A62A4B387A00B8DF4F /* AccountSetting */ = {
 			isa = PBXGroup;
 			children = (
@@ -1396,6 +1416,7 @@
 				BAE442C22A6D2C7A00BD6582 /* LoadingReusableView.swift in Sources */,
 				F0687BED2A529679004B5EAE /* Config.swift in Sources */,
 				B28205032A346FDD00F9242F /* ProfileHomeViewController.swift in Sources */,
+				F0E915AF2AA87B97000919DA /* ControlPublisher.swift in Sources */,
 				F0EE10A32A4B242C00B8DF4F /* ProfileCell.swift in Sources */,
 				B24F1D362A43E5B500AA03DC /* ProductListViewController.swift in Sources */,
 				B28A59172A6E995500431F39 /* CurationEntity.swift in Sources */,
@@ -1405,12 +1426,14 @@
 				BA50FD042A680AA900721782 /* ProductSearchInteractor.swift in Sources */,
 				B28A592A2A6FCFED00431F39 /* SortFilterCell.swift in Sources */,
 				F0EE10A12A4B122A00B8DF4F /* UITableView+.swift in Sources */,
+				F0E915AC2AA87913000919DA /* CombineCocoa+.swift in Sources */,
 				B28A59222A6FB2B200431F39 /* ProductFilterRouter.swift in Sources */,
 				B24CAAE22A55AC2B005BE499 /* NotificationListViewHolder.swift in Sources */,
 				B28205152A34702B00F9242F /* ProductHomeInteractor.swift in Sources */,
 				F0168D532A500AC900978ED9 /* EventDetailBuilder.swift in Sources */,
 				F015353B2A45A51000A2A8F2 /* EventHomeTabViewController.swift in Sources */,
 				F00609522A5EED4600A2A79D /* SettingInfo.swift in Sources */,
+				F0E915AA2AA8711B000919DA /* UIControl+.swift in Sources */,
 				F0C87AF32A51DFC300EA4C76 /* ErrorResponse.swift in Sources */,
 				F0DFBC9F2A596953003F7660 /* MemberInfoEntity.swift in Sources */,
 				BA9E233B2A21EF3000A539D5 /* AppDelegate.swift in Sources */,
@@ -1494,6 +1517,7 @@
 				F0A8A3B02A70053D00601DAE /* FilterType.swift in Sources */,
 				BA87E3D72A45D40A000A9DEC /* GiftInformationView.swift in Sources */,
 				B24259142A595B9B006C5223 /* ProductConvertable.swift in Sources */,
+				F0E915B12AA87BB4000919DA /* ControlSubscription.swift in Sources */,
 				B28205042A346FDD00F9242F /* ProfileHomeBuilder.swift in Sources */,
 				B24F1D312A431E1700AA03DC /* ConvenienceStoreCell.swift in Sources */,
 				BA4818CD2A59405300BF9CAD /* AuthAPIService.swift in Sources */,

--- a/Pyonsnal-Color/Pyonsnal-Color/Common/Combine/ControlPublisher.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Common/Combine/ControlPublisher.swift
@@ -1,0 +1,31 @@
+//
+//  ControlPublisher.swift
+//  Pyonsnal-Color
+//
+//  Created by 조소정 on 2023/09/06.
+//
+
+import UIKit
+import Combine
+
+struct ControlPublisher: Publisher {
+    typealias Output = UIControl
+    typealias Failure = Never
+    
+    private let control: UIControl
+    private let controlEvent: UIControl.Event
+    
+    init(control: UIControl, controlEvent: UIControl.Event) {
+        self.control = control
+        self.controlEvent = controlEvent
+    }
+    
+    func receive<S>(subscriber: S) where S: Subscriber, Never == S.Failure, UIControl == S.Input {
+        let subscription = ControlSubscription(
+            subscriber: subscriber,
+            control: control,
+            controlEvent: controlEvent
+        )
+        subscriber.receive(subscription: subscription)
+    }
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/Common/Combine/ControlSubscription.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Common/Combine/ControlSubscription.swift
@@ -1,0 +1,36 @@
+//
+//  ControlSubscription.swift
+//  Pyonsnal-Color
+//
+//  Created by 조소정 on 2023/09/06.
+//
+
+import UIKit
+import Combine
+
+final class ControlSubscription<ControlSubscriber: Subscriber>: Subscription where ControlSubscriber.Input == ControlPublisher.Output, ControlSubscriber.Failure == ControlPublisher.Failure {
+    private let selector = #selector(eventHandler)
+    private var subscriber: ControlSubscriber?
+    private let control: UIControl
+    private let controlEvent: UIControl.Event
+    
+    init(subscriber: ControlSubscriber, control: UIControl, controlEvent: UIControl.Event) {
+        self.subscriber = subscriber
+        self.control = control
+        self.controlEvent = controlEvent
+        control.addTarget(self, action: selector, for: controlEvent)
+    }
+    
+    func request(_ demand: Subscribers.Demand) { } // 구현 필요 없음
+    
+    func cancel() {
+        subscriber = nil
+        control.removeTarget(self, action: selector, for: controlEvent)
+    }
+    
+    @objc
+    func eventHandler() {
+        _ = subscriber?.receive(control)
+    }
+}
+       

--- a/Pyonsnal-Color/Pyonsnal-Color/Common/Combine/GesturePublisher.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Common/Combine/GesturePublisher.swift
@@ -1,0 +1,28 @@
+//
+//  GesturePublisher.swift
+//  Pyonsnal-Color
+//
+//  Created by 조소정 on 2023/09/06.
+//
+
+import UIKit
+import Combine
+
+struct GesturePublisher: Publisher {
+    
+    typealias Output = UIGestureRecognizer
+    typealias Failure = Never
+    
+    private weak var targetView: UIView?
+    private let gestureRecognizer: UIGestureRecognizer
+    
+    init(targetView: UIView, gestureRecognizer: UIGestureRecognizer) {
+        self.targetView = targetView
+        self.gestureRecognizer = gestureRecognizer
+    }
+    
+    func receive<S>(subscriber: S) where S : Subscriber, Never == S.Failure, UIGestureRecognizer == S.Input {
+        let subscription = GestureSubscription(subscriber: subscriber, view: targetView, gestureRecognizer: gestureRecognizer)
+        subscriber.receive(subscription: subscription)
+    }
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/Common/Combine/GestureSubscription.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Common/Combine/GestureSubscription.swift
@@ -1,0 +1,39 @@
+//
+//  GestureSubscription.swift
+//  Pyonsnal-Color
+//
+//  Created by 조소정 on 2023/09/06.
+//
+
+import UIKit
+import Combine
+
+final class GestureSubscription<GestureSubscriber: Subscriber>: Subscription where GestureSubscriber.Input == GesturePublisher.Output, GestureSubscriber.Failure == GesturePublisher.Failure {
+    private let selector = #selector(gestureHandler)
+    private var subscriber: GestureSubscriber?
+    private weak var targetView: UIView?
+    private let gestureRecognizer: UIGestureRecognizer
+    
+    init(subscriber: GestureSubscriber?, view: UIView?, gestureRecognizer: UIGestureRecognizer) {
+        self.subscriber = subscriber
+        self.targetView = view
+        self.gestureRecognizer = gestureRecognizer
+        
+        self.targetView?.isUserInteractionEnabled = true
+        gestureRecognizer.addTarget(self, action: selector)
+        self.targetView?.addGestureRecognizer(gestureRecognizer)
+    }
+    
+    func request(_ demand: Subscribers.Demand) { } // 구현 필요 없음
+    
+    func cancel() {
+        subscriber = nil
+        targetView?.isUserInteractionEnabled = false
+        gestureRecognizer.removeTarget(self, action: selector)
+    }
+    
+    @objc
+    private func gestureHandler() {
+        _ = subscriber?.receive(gestureRecognizer)
+    }
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/Extension/CombineCocoa+.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Extension/CombineCocoa+.swift
@@ -1,0 +1,26 @@
+//
+//  CombineCocoa+.swift
+//  Pyonsnal-Color
+//
+//  Created by 조소정 on 2023/09/06.
+//
+
+import UIKit
+import Combine
+
+extension UIButton {
+    var tapPublisher: AnyPublisher<Void, Never> {
+        return controlPublisher(for: .touchUpInside)
+            .map { _ in }
+            .eraseToAnyPublisher()
+    }
+}
+
+extension UITextField {
+    var textPublisher: AnyPublisher<String?, Never> {
+        return controlPublisher(for: .editingChanged)
+            .compactMap { $0 as? UITextField }
+            .map { $0.text }
+            .eraseToAnyPublisher()
+    }
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/Extension/CombineCocoa+.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Extension/CombineCocoa+.swift
@@ -24,3 +24,12 @@ extension UITextField {
             .eraseToAnyPublisher()
     }
 }
+
+extension UIView {
+    func gesturePublisher(with delegate: UIGestureRecognizerDelegate) -> GesturePublisher {
+        /// 현재는 tapGesture가 default. 추후 다른 gesture가 필요로 되면 gestureRecognizer 확장하여 사용.
+        let gestureRecognizer = UITapGestureRecognizer()
+        gestureRecognizer.delegate = delegate
+        return GesturePublisher(targetView: self, gestureRecognizer: gestureRecognizer)
+    }
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/Extension/UIControl+.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Extension/UIControl+.swift
@@ -1,0 +1,15 @@
+//
+//  UIControl+.swift
+//  Pyonsnal-Color
+//
+//  Created by 조소정 on 2023/09/06.
+//
+
+import UIKit
+import Combine
+
+extension UIControl {
+    func controlPublisher(for event: UIControl.Event) -> ControlPublisher {
+        return ControlPublisher(control: self, controlEvent: event)
+    }
+}


### PR DESCRIPTION
### 수정사항
CombineCocoa 라이브러리와 같이 UI event를 방출하는 extension을 추가하였습니다.
https://github.com/CombineCommunity/CombineCocoa

사용하는 쪽에서는 아래와 같이 사용할 수 있습니다 !
- controlPublisher
```
        viewHolder.closeButton.addTarget( // 기존 방식
            self,
            action: #selector(didTapCloseButton),
            for: .touchUpInside
        )
        viewHolder.closeButton // tapPublisher
            .tapPublisher
            .throttle(for: 0.2, scheduler: RunLoop.main, latest: false)
            .sink { [weak self] in
                self?.didTapCloseButton()
            }.store(in: &cancellable)
```

- gesturePublisher

 ```
 let gestureRecognizer = UITapGestureRecognizer(  // 기존 방식
            target: self,
            action: #selector(didTapBackgroundView)
        )
        gestureRecognizer.delegate = self
        view.addGestureRecognizer(gestureRecognizer)
        
        view.gesturePublisher(with: self) // gesturePublisher
            .throttle(for: 0.2, scheduler: RunLoop.main, latest: false)
            .sink { [weak self] _ in
                self?.didTapBackgroundView()
            }.store(in: &cancellable)

```