### PR TITLE
리뷰 등록 관련 QA 수정 0.2.0(3)

### DIFF
--- a/Pyonsnal-Color/Pyonsnal-Color/DetailReview/DetailReviewViewHolder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/DetailReview/DetailReviewViewHolder.swift
@@ -36,7 +36,11 @@ extension DetailReviewViewController {
             return navigationView
         }()
         
-        private let totalScrollView = UIScrollView()
+        private let totalScrollView: UIScrollView = {
+            let scrollView = UIScrollView()
+            scrollView.keyboardDismissMode = .onDrag
+            return scrollView
+        }()
         
         private let contentStackView: UIStackView = {
             let stackView = UIStackView()

--- a/Pyonsnal-Color/Pyonsnal-Color/DetailReview/DetailReviewViewHolder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/DetailReview/DetailReviewViewHolder.swift
@@ -31,6 +31,7 @@ extension DetailReviewViewController {
                 title: Constant.navigationTitle,
                 iconImageKind: nil
             )
+            navigationView.favoriteButton.isHidden = true
             navigationView.setText(with: Constant.navigationTitle)
             return navigationView
         }()

--- a/Pyonsnal-Color/Pyonsnal-Color/DetailReview/DetailReviewViewHolder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/DetailReview/DetailReviewViewHolder.swift
@@ -257,7 +257,8 @@ extension DetailReviewViewController {
             }
             
             applyReviewButton.snp.makeConstraints {
-                $0.bottom.equalTo(totalScrollView.frameLayoutGuide)
+                $0.bottom.equalTo(view.safeAreaLayoutGuide).priority(.high)
+                $0.bottom.lessThanOrEqualTo(view).inset(.spacing20)
                 $0.leading.equalToSuperview().offset(16)
                 $0.trailing.equalToSuperview().inset(16)
                 $0.height.equalTo(52)

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductDetail/ProductDetailViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductDetail/ProductDetailViewController.swift
@@ -66,7 +66,7 @@ final class ProductDetailViewController:
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-//        listener?.attachStarRatingReview()
+        listener?.refresh()
     }
     
     // MARK: - Private Method

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductDetail/ProductDetailViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductDetail/ProductDetailViewController.swift
@@ -63,7 +63,7 @@ final class ProductDetailViewController:
         viewHolder.collectionView.delegate = self
     }
     
-    override func viewDidAppear(_ animated: Bool) {
+    override func viewWillAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
         listener?.refresh()

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductDetail/Subview/ReviewMetaView/ReviewMetaView.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductDetail/Subview/ReviewMetaView/ReviewMetaView.swift
@@ -74,7 +74,7 @@ final class ReviewMetaView: UIView {
         profileImageView.setImage(.tagStore)
         nameLabel.text = review.writerName
         ratingPreviewView.payload = .init(ratingCount: Int(review.score))
-//        dateLabel.text = review.
+        dateLabel.text = review.updatedTime
     }
     
     private func configureView() {

--- a/Pyonsnal-Color/Pyonsnal-Color/StarRatingReview/StarRatingReviewViewHolder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/StarRatingReview/StarRatingReviewViewHolder.swift
@@ -29,6 +29,7 @@ extension StarRatingReviewViewController {
                 title: Constant.navigationTitle,
                 iconImageKind: nil
             )
+            navigationView.favoriteButton.isHidden = true
             navigationView.setText(with: Constant.navigationTitle)
             return navigationView
         }()


### PR DESCRIPTION
### 수정사항

#### 💫 기능 QA
1. 리뷰 작성 완료 후 상품 상세 화면으로 돌아왔을때 새로 작성한 리뷰가 반영되어 화면에 보여지도록 수정했습니다.
(ProductDetail 뷰컨에서 `viewwillAppear` 에 `refresh()` 호출)
2. 상세 리뷰 작성 후 스크롤 뷰 드래그 시 키보드 내려가도록 수정했습니다.
#### 🍎 디자인 QA
(디자인 QA는 모두 수정했습니다!)
1. SE2 기기에서 리뷰 작성완료 버튼이 하단에 붙어있는 버그 수정했습니다.
2. 리뷰 등록 날짜가 보여지지 않는 버그 수정했습니다.
3. 별점 리뷰, 상세 리뷰 화면의 네비게이션 헤더에 찜하기 버튼이 보여지지 않도록 수정했습니다. 