### PR TITLE
0.9(1) 기능 QA 및 0.2(3) 디자인 QA

### DIFF
--- a/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
+++ b/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		B242590E2A5947E7006C5223 /* PageableEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B242590D2A5947E7006C5223 /* PageableEntity.swift */; };
 		B24259102A594862006C5223 /* SortEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B242590F2A594862006C5223 /* SortEntity.swift */; };
 		B24259122A594AB7006C5223 /* ProductAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24259112A594AB7006C5223 /* ProductAPI.swift */; };
+		B248916B2B3D5A75009D0FBF /* UserReviewInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = B248916A2B3D5A75009D0FBF /* UserReviewInput.swift */; };
 		B24CAAE22A55AC2B005BE499 /* NotificationListViewHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24F1D472A4AD7ED00AA03DC /* NotificationListViewHolder.swift */; };
 		B24CAAE32A55AC2D005BE499 /* NotificationListBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24F1D412A4AD7B600AA03DC /* NotificationListBuilder.swift */; };
 		B24CAAE42A55AC2F005BE499 /* NotificationListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24F1D422A4AD7B600AA03DC /* NotificationListInteractor.swift */; };
@@ -344,6 +345,7 @@
 		B242590D2A5947E7006C5223 /* PageableEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageableEntity.swift; sourceTree = "<group>"; };
 		B242590F2A594862006C5223 /* SortEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortEntity.swift; sourceTree = "<group>"; };
 		B24259112A594AB7006C5223 /* ProductAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAPI.swift; sourceTree = "<group>"; };
+		B248916A2B3D5A75009D0FBF /* UserReviewInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserReviewInput.swift; sourceTree = "<group>"; };
 		B24F1D302A431E1700AA03DC /* ConvenienceStoreCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConvenienceStoreCell.swift; sourceTree = "<group>"; };
 		B24F1D352A43E5B500AA03DC /* ProductListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListViewController.swift; sourceTree = "<group>"; };
 		B24F1D372A44171800AA03DC /* ProductHomePageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductHomePageViewController.swift; sourceTree = "<group>"; };
@@ -1134,6 +1136,7 @@
 				BAE252292AC6DC0600405DEC /* ReviewQualityEvaluation.swift */,
 				BAE2522B2AC6DC1900405DEC /* ReviewValueForMoneyEvaluation.swift */,
 				BA1E8BB22ACBC2E300964B6E /* ReviewFeedKind.swift */,
+				B248916A2B3D5A75009D0FBF /* UserReviewInput.swift */,
 			);
 			path = Review;
 			sourceTree = "<group>";
@@ -2039,6 +2042,7 @@
 				B282050B2A34700300F9242F /* EventHomeViewController.swift in Sources */,
 				BA18C0942A754225007D00BD /* SearchFilterHeaderDelegate.swift in Sources */,
 				F097EF352A571DD300A7FB9C /* CommonWebViewController.swift in Sources */,
+				B248916B2B3D5A75009D0FBF /* UserReviewInput.swift in Sources */,
 				F068A9702A99E76A000AFD52 /* FilterRenderable.swift in Sources */,
 				F0B6E6C72AB8A2DB00AA7006 /* ProductCell+ViewHolder.swift in Sources */,
 				F040E9D32A6D8E8800DF0C4A /* RefreshFilterCell.swift in Sources */,

--- a/Pyonsnal-Color/Pyonsnal-Color/DetailReview/DetailReviewBuilder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/DetailReview/DetailReviewBuilder.swift
@@ -28,7 +28,8 @@ protocol DetailReviewBuildable: Buildable {
     func build(
         withListener listener: DetailReviewListener,
         productDetail: ProductDetailEntity,
-        score: Int
+        score: Int,
+        userReviewInput: UserReviewInput
     ) -> DetailReviewRouting
 }
 
@@ -41,10 +42,15 @@ final class DetailReviewBuilder: Builder<DetailReviewDependency>, DetailReviewBu
     func build(
         withListener listener: DetailReviewListener,
         productDetail: ProductDetailEntity,
-        score: Int
+        score: Int,
+        userReviewInput: UserReviewInput
     ) -> DetailReviewRouting {
         let component = DetailReviewComponent(dependency: dependency)
-        let viewController = DetailReviewViewController(productDetail: productDetail, score: score)
+        let viewController = DetailReviewViewController(
+            productDetail: productDetail,
+            score: score,
+            userReviewInput: userReviewInput
+        )
         let interactor = DetailReviewInteractor(
             presenter: viewController,
             component: component,

--- a/Pyonsnal-Color/Pyonsnal-Color/DetailReview/DetailReviewInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/DetailReview/DetailReviewInteractor.swift
@@ -25,6 +25,7 @@ protocol DetailReviewPresentable: Presentable {
 protocol DetailReviewListener: AnyObject {
     func detachDetailReview()
     func routeToProductDetail()
+    func saveReviewInput(_ input: UserReviewInput)
 }
 
 final class DetailReviewInteractor: PresentableInteractor<DetailReviewPresentable>,
@@ -61,6 +62,13 @@ final class DetailReviewInteractor: PresentableInteractor<DetailReviewPresentabl
     }
     
     func didTapBackButton() {
+        let review = UserReviewInput(
+            reviews: presenter.reviews,
+            reviewContents: presenter.getReviewContents(),
+            reviewImage: presenter.getReviewImage()
+        )
+        
+        listener?.saveReviewInput(review)
         listener?.detachDetailReview()
     }
     

--- a/Pyonsnal-Color/Pyonsnal-Color/DetailReview/DetailReviewInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/DetailReview/DetailReviewInteractor.swift
@@ -61,7 +61,7 @@ final class DetailReviewInteractor: PresentableInteractor<DetailReviewPresentabl
     }
     
     func didTapBackButton() {
-        router?.attachPopup(isApply: false)
+        listener?.detachDetailReview()
     }
     
     func didTapApplyButton() {

--- a/Pyonsnal-Color/Pyonsnal-Color/DetailReview/DetailReviewViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/DetailReview/DetailReviewViewController.swift
@@ -32,10 +32,12 @@ final class DetailReviewViewController: UIViewController,
     private var cancellable = Set<AnyCancellable>()
     private(set) var reviews: [ReviewEvaluationKind: ReviewEvaluationState] = [:]
     private(set) var score: Int
+    private(set) var userReviewInput: UserReviewInput
     
-    init(productDetail: ProductDetailEntity, score: Int) {
+    init(productDetail: ProductDetailEntity, score: Int, userReviewInput: UserReviewInput) {
         self.productDetail = productDetail
         self.score = score
+        self.userReviewInput = userReviewInput
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -53,6 +55,7 @@ final class DetailReviewViewController: UIViewController,
         configureImageUploadButton()
         configureDeleteImageButton()
         configureApplyReviewButton()
+        configureUserReviewInput()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -119,6 +122,28 @@ final class DetailReviewViewController: UIViewController,
             .sink { [weak self] in
                 self?.listener?.didTapApplyButton()
             }.store(in: &cancellable)
+    }
+    
+    private func configureUserReviewInput() {
+        userReviewInput.reviews.forEach { (value, state) in
+            switch value {
+            case .quality:
+                viewHolder.qualityReview.selectReviewButton(state)
+            case .taste:
+                viewHolder.tasteReview.selectReviewButton(state)
+            case .valueForMoney:
+                viewHolder.priceReview.selectReviewButton(state)
+            }
+        }
+        
+        if !userReviewInput.reviewContents.isEmpty {
+            viewHolder.detailReviewTextView.text = userReviewInput.reviewContents
+            viewHolder.detailReviewTextView.textColor = .black
+        }
+        
+        if let image = userReviewInput.reviewImage {
+            updateProductImage(image)
+        }
     }
     
     private func showImageLibrary() {

--- a/Pyonsnal-Color/Pyonsnal-Color/DetailReview/DetailReviewViewHolder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/DetailReview/DetailReviewViewHolder.swift
@@ -204,6 +204,12 @@ extension DetailReviewViewController {
             return button
         }()
         
+        private let applyButtonBackgroundView: UIView = {
+            let view = UIView()
+            view.backgroundColor = .white
+            return view
+        }()
+        
         let applyReviewButton: PrimaryButton = {
             let button = PrimaryButton(state: .disabled)
             button.setText(with: Constant.applyReviewTitle)
@@ -215,7 +221,9 @@ extension DetailReviewViewController {
             view.addSubview(totalScrollView)
             
             totalScrollView.addSubview(contentStackView)
-            totalScrollView.addSubview(applyReviewButton)
+            totalScrollView.addSubview(applyButtonBackgroundView)
+            
+            applyButtonBackgroundView.addSubview(applyReviewButton)
             
             contentStackView.addArrangedSubview(productTotalStackView)
             contentStackView.addArrangedSubview(separatorView)
@@ -260,12 +268,17 @@ extension DetailReviewViewController {
                 $0.height.greaterThanOrEqualToSuperview()
             }
             
-            applyReviewButton.snp.makeConstraints {
+            applyButtonBackgroundView.snp.makeConstraints {
+                $0.leading.trailing.equalToSuperview()
                 $0.bottom.equalTo(view.safeAreaLayoutGuide).priority(.high)
                 $0.bottom.lessThanOrEqualTo(view).inset(.spacing20)
+                $0.height.equalTo(52)
+            }
+            
+            applyReviewButton.snp.makeConstraints {
                 $0.leading.equalToSuperview().offset(16)
                 $0.trailing.equalToSuperview().inset(16)
-                $0.height.equalTo(52)
+                $0.height.equalToSuperview()
             }
             
             productTotalStackView.snp.makeConstraints {

--- a/Pyonsnal-Color/Pyonsnal-Color/DetailReview/Views/SingleLineReview.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/DetailReview/Views/SingleLineReview.swift
@@ -97,6 +97,14 @@ final class SingleLineReview: UIView {
         
         return result == 1 ? true : false
     }
+    
+    func selectReviewButton(_ state: ReviewEvaluationState) {
+        let result = viewHolder.reviewButtonStackView.subviews
+            .compactMap { $0 as? ReviewButton }
+            .filter { $0.payload?.state == state }
+        
+        result.forEach { didSelectReviewButton($0) }
+    }
 }
 
 extension SingleLineReview {

--- a/Pyonsnal-Color/Pyonsnal-Color/Entity/Review/UserReviewInput.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Entity/Review/UserReviewInput.swift
@@ -1,0 +1,14 @@
+//
+//  UserReviewInput.swift
+//  Pyonsnal-Color
+//
+//  Created by 김인호 on 12/28/23.
+//
+
+import UIKit
+
+struct UserReviewInput {
+    let reviews: [ReviewEvaluationKind : ReviewEvaluationState]
+    let reviewContents: String
+    let reviewImage: UIImage?
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductFilter/ProductFilterViewController.swift
@@ -59,6 +59,8 @@ final class ProductFilterViewController:
     
     // MARK: - Private Method
     private func configureView() {
+        // TODO: 임시 Hidden - swipe gesture 추가 예정
+        viewHolder.grabView.isHidden = true
         setFilterTitle()
         setMultiSelect()
         hideApplyButton()
@@ -325,7 +327,7 @@ extension ProductFilterViewController {
             return view
         }()
         
-        private let grabView: UIView = {
+        let grabView: UIView = {
             let view = UIView()
             view.makeRounded(with: Size.grabViewRadius)
             view.backgroundColor = .gray400

--- a/Pyonsnal-Color/Pyonsnal-Color/StarRatingReview/StarRatingReviewBuilder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/StarRatingReview/StarRatingReviewBuilder.swift
@@ -11,7 +11,8 @@ protocol StarRatingReviewDependency: Dependency {
 }
 
 final class StarRatingReviewComponent: Component<StarRatingReviewDependency>,
-                                       DetailReviewDependency {
+                                       DetailReviewDependency,
+                                       ReviewPopupDependency {
 }
 
 // MARK: - Builder
@@ -41,11 +42,13 @@ final class StarRatingReviewBuilder: Builder<StarRatingReviewDependency>,
             productDetail: productDetail
         )
         let detailReviewBuilder = DetailReviewBuilder(dependency: component)
+        let reviewPopupBuilder = ReviewPopupBuilder(dependency: component)
         interactor.listener = listener
         return StarRatingReviewRouter(
             interactor: interactor,
             viewController: viewController,
-            detailReviewBuilder: detailReviewBuilder
+            detailReviewBuilder: detailReviewBuilder, 
+            reviewPopupBuilder: reviewPopupBuilder
         )
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/StarRatingReview/StarRatingReviewInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/StarRatingReview/StarRatingReviewInteractor.swift
@@ -10,6 +10,8 @@ import ModernRIBs
 protocol StarRatingReviewRouting: ViewableRouting {
     func attachDetailReview(productDetail: ProductDetailEntity, score: Int)
     func detachDetailReview(animated: Bool)
+    func attachPopup(isApply: Bool)
+    func detachPopup()
 }
 
 protocol StarRatingReviewPresentable: Presentable {
@@ -57,6 +59,15 @@ final class StarRatingReviewInteractor: PresentableInteractor<StarRatingReviewPr
     }
     
     func didTapBackButton() {
+        router?.attachPopup(isApply: false)
+    }
+    
+    func popupDidTapDismissButton() {
+        router?.detachPopup()
+    }
+    
+    func popupDidTapBackButton() {
+        router?.detachPopup()
         listener?.detachStarRatingReview()
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/StarRatingReview/StarRatingReviewInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/StarRatingReview/StarRatingReviewInteractor.swift
@@ -5,10 +5,15 @@
 //  Created by 김인호 on 2023/09/21.
 //
 
+import UIKit
 import ModernRIBs
 
 protocol StarRatingReviewRouting: ViewableRouting {
-    func attachDetailReview(productDetail: ProductDetailEntity, score: Int)
+    func attachDetailReview(
+        productDetail: ProductDetailEntity,
+        score: Int,
+        userReviewInput: UserReviewInput
+    )
     func detachDetailReview(animated: Bool)
     func attachPopup(isApply: Bool)
     func detachPopup()
@@ -30,6 +35,11 @@ final class StarRatingReviewInteractor: PresentableInteractor<StarRatingReviewPr
     weak var listener: StarRatingReviewListener?
     
     private let productDetail: ProductDetailEntity
+    private var userReviewInput: UserReviewInput = .init(
+        reviews: [:],
+        reviewContents: String(),
+        reviewImage: nil
+    )
 
     init(presenter: StarRatingReviewPresentable, productDetail: ProductDetailEntity) {
         self.productDetail = productDetail
@@ -46,7 +56,11 @@ final class StarRatingReviewInteractor: PresentableInteractor<StarRatingReviewPr
     }
     
     func didTapRatingButton(score: Int) {
-        router?.attachDetailReview(productDetail: productDetail, score: score)
+        router?.attachDetailReview(
+            productDetail: productDetail,
+            score: score,
+            userReviewInput: userReviewInput
+        )
     }
     
     func detachDetailReview() {
@@ -69,5 +83,9 @@ final class StarRatingReviewInteractor: PresentableInteractor<StarRatingReviewPr
     func popupDidTapBackButton() {
         router?.detachPopup()
         listener?.detachStarRatingReview()
+    }
+    
+    func saveReviewInput(_ input: UserReviewInput) {
+        userReviewInput = input
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/StarRatingReview/StarRatingReviewRouter.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/StarRatingReview/StarRatingReviewRouter.swift
@@ -5,6 +5,7 @@
 //  Created by 김인호 on 2023/09/21.
 //
 
+import UIKit
 import ModernRIBs
 
 protocol StarRatingReviewInteractable: Interactable, DetailReviewListener, ReviewPopupListener {
@@ -37,13 +38,18 @@ final class StarRatingReviewRouter: ViewableRouter<StarRatingReviewInteractable,
         interactor.router = self
     }
     
-    func attachDetailReview(productDetail: ProductDetailEntity, score: Int) {
+    func attachDetailReview(
+        productDetail: ProductDetailEntity,
+        score: Int,
+        userReviewInput: UserReviewInput
+    ) {
         guard detailReviewRouting == nil else { return }
         
         let detailReviewRouter = detailReviewBuilder.build(
             withListener: interactor,
             productDetail: productDetail,
-            score: score
+            score: score,
+            userReviewInput: userReviewInput
         )
         detailReviewRouting = detailReviewRouter
         attachChild(detailReviewRouter)


### PR DESCRIPTION
### 이슈
#151 

### 수정사항
#### 기능 QA
- 리뷰 작성 중 뒤로가기 버튼 누를 시 팝업 위치 (기존: 상세리뷰 -> 수정 후: 별점 리뷰) 변경 
- 상세리뷰 작성 중 뒤로가기 시 작성기록 유지

#### 디자인 QA
- 상세리뷰 화면의 작성완료 버튼 뒤에 흰색 뷰 추가
- 상품 필터의 회색 드래그 바 임시 hidden 처리

### 스크린샷
|<img src="https://github.com/YAPP-Github/PyonsnalColor-iOS/assets/71054048/eb5ad0c1-e7b2-48b3-92c7-d3443dc4f15a" width=270>|<img src="https://github.com/YAPP-Github/PyonsnalColor-iOS/assets/71054048/1985ecbb-c008-4d23-b02b-ea77212d0c0d" width=270>|
|:-:|:-:|
|뒤로가기 팝업|리뷰 작성기록 유지|


