### PR TITLE
로그인 관련 기능에 로그인 팝업 및 로그인 화면 연결

### DIFF
--- a/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
+++ b/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
@@ -103,6 +103,8 @@
 		B2C25CDA2B65166E005C6F0D /* EmptyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C25CD72B65166E005C6F0D /* EmptyResponse.swift */; };
 		B2C25CDB2B65166E005C6F0D /* ProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C25CD82B65166E005C6F0D /* ProductType.swift */; };
 		B2C25CDC2B65166E005C6F0D /* ErrorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C25CD92B65166E005C6F0D /* ErrorResponse.swift */; };
+		B2EECB692B6A6EFD00B328C1 /* PopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2EECB682B6A6EFD00B328C1 /* PopupView.swift */; };
+		B2EECB6B2B6A71E000B328C1 /* PopupViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2EECB6A2B6A71E000B328C1 /* PopupViewDelegate.swift */; };
 		B2EFFAB92ACBF63D007AF2EE /* StarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2EFFAB82ACBF63D007AF2EE /* StarView.swift */; };
 		B2EFFABB2ACBF680007AF2EE /* StarRatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2EFFABA2ACBF680007AF2EE /* StarRatingView.swift */; };
 		B2EFFABD2ACBF69C007AF2EE /* StarRatedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2EFFABC2ACBF69C007AF2EE /* StarRatedView.swift */; };
@@ -422,6 +424,8 @@
 		B2C25CD72B65166E005C6F0D /* EmptyResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyResponse.swift; sourceTree = "<group>"; };
 		B2C25CD82B65166E005C6F0D /* ProductType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductType.swift; sourceTree = "<group>"; };
 		B2C25CD92B65166E005C6F0D /* ErrorResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorResponse.swift; sourceTree = "<group>"; };
+		B2EECB682B6A6EFD00B328C1 /* PopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupView.swift; sourceTree = "<group>"; };
+		B2EECB6A2B6A71E000B328C1 /* PopupViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupViewDelegate.swift; sourceTree = "<group>"; };
 		B2EFFAB82ACBF63D007AF2EE /* StarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarView.swift; sourceTree = "<group>"; };
 		B2EFFABA2ACBF680007AF2EE /* StarRatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarRatingView.swift; sourceTree = "<group>"; };
 		B2EFFABC2ACBF69C007AF2EE /* StarRatedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarRatedView.swift; sourceTree = "<group>"; };
@@ -962,6 +966,15 @@
 			path = LauncingEvent;
 			sourceTree = "<group>";
 		};
+		B2EECB672B6A6EEC00B328C1 /* Popup */ = {
+			isa = PBXGroup;
+			children = (
+				B2EECB682B6A6EFD00B328C1 /* PopupView.swift */,
+				B2EECB6A2B6A71E000B328C1 /* PopupViewDelegate.swift */,
+			);
+			path = Popup;
+			sourceTree = "<group>";
+		};
 		B2F169D42A3471EB008199D8 /* RootTabBar */ = {
 			isa = PBXGroup;
 			children = (
@@ -1401,6 +1414,7 @@
 		BAEA1BFB2A3477A80028A90A /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				B2EECB672B6A6EEC00B328C1 /* Popup */,
 				B248917D2B5FA086009D0FBF /* UserEvent */,
 				B224963E2ABAEB8E00BC6B09 /* Review */,
 				F0E915AD2AA87B86000919DA /* Combine */,
@@ -2114,6 +2128,7 @@
 				F0C698652A6BA9B00019C677 /* CategoryFilterCell.swift in Sources */,
 				B24259032A590ECA006C5223 /* ConvenienceStore.swift in Sources */,
 				B24891652B3AD343009D0FBF /* EventImageEntity.swift in Sources */,
+				B2EECB692B6A6EFD00B328C1 /* PopupView.swift in Sources */,
 				BA6CAB842AE8509900B9E1BF /* ReviewHateCountEntity.swift in Sources */,
 				B28A59322A73B08000431F39 /* RecommendFilterCell.swift in Sources */,
 				BA00B7362A46B83A00BB3795 /* CGFloat+.swift in Sources */,
@@ -2132,6 +2147,7 @@
 				F097EF2C2A57181B00A7FB9C /* TermsOfUseUrl.swift in Sources */,
 				F00352212A62B9F000A66FF9 /* AuthType.swift in Sources */,
 				BA8322512AB6F40A00D2E1EB /* ReviewMetaView.swift in Sources */,
+				B2EECB6B2B6A71E000B328C1 /* PopupViewDelegate.swift in Sources */,
 				F013DECB2AFF6BFA00A1F34C /* FavoriteHomeDelegate.swift in Sources */,
 				B28205022A346FDD00F9242F /* ProfileHomeRouter.swift in Sources */,
 				F01535452A45A6F800A2A8F2 /* ItemHeaderTitleView.swift in Sources */,

--- a/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
+++ b/Pyonsnal-Color/Pyonsnal-Color.xcodeproj/project.pbxproj
@@ -105,6 +105,11 @@
 		B2C25CDC2B65166E005C6F0D /* ErrorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C25CD92B65166E005C6F0D /* ErrorResponse.swift */; };
 		B2EECB692B6A6EFD00B328C1 /* PopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2EECB682B6A6EFD00B328C1 /* PopupView.swift */; };
 		B2EECB6B2B6A71E000B328C1 /* PopupViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2EECB6A2B6A71E000B328C1 /* PopupViewDelegate.swift */; };
+		B2EECB722B6A894200B328C1 /* LoginPopupRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2EECB6E2B6A894200B328C1 /* LoginPopupRouter.swift */; };
+		B2EECB732B6A894200B328C1 /* LoginPopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2EECB6F2B6A894200B328C1 /* LoginPopupViewController.swift */; };
+		B2EECB742B6A894200B328C1 /* LoginPopupBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2EECB702B6A894200B328C1 /* LoginPopupBuilder.swift */; };
+		B2EECB752B6A894200B328C1 /* LoginPopupInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2EECB712B6A894200B328C1 /* LoginPopupInteractor.swift */; };
+		B2EECB772B6A896600B328C1 /* LoginPopupViewHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2EECB762B6A896600B328C1 /* LoginPopupViewHolder.swift */; };
 		B2EFFAB92ACBF63D007AF2EE /* StarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2EFFAB82ACBF63D007AF2EE /* StarView.swift */; };
 		B2EFFABB2ACBF680007AF2EE /* StarRatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2EFFABA2ACBF680007AF2EE /* StarRatingView.swift */; };
 		B2EFFABD2ACBF69C007AF2EE /* StarRatedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2EFFABC2ACBF69C007AF2EE /* StarRatedView.swift */; };
@@ -426,6 +431,11 @@
 		B2C25CD92B65166E005C6F0D /* ErrorResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorResponse.swift; sourceTree = "<group>"; };
 		B2EECB682B6A6EFD00B328C1 /* PopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupView.swift; sourceTree = "<group>"; };
 		B2EECB6A2B6A71E000B328C1 /* PopupViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupViewDelegate.swift; sourceTree = "<group>"; };
+		B2EECB6E2B6A894200B328C1 /* LoginPopupRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginPopupRouter.swift; sourceTree = "<group>"; };
+		B2EECB6F2B6A894200B328C1 /* LoginPopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginPopupViewController.swift; sourceTree = "<group>"; };
+		B2EECB702B6A894200B328C1 /* LoginPopupBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginPopupBuilder.swift; sourceTree = "<group>"; };
+		B2EECB712B6A894200B328C1 /* LoginPopupInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginPopupInteractor.swift; sourceTree = "<group>"; };
+		B2EECB762B6A896600B328C1 /* LoginPopupViewHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginPopupViewHolder.swift; sourceTree = "<group>"; };
 		B2EFFAB82ACBF63D007AF2EE /* StarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarView.swift; sourceTree = "<group>"; };
 		B2EFFABA2ACBF680007AF2EE /* StarRatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarRatingView.swift; sourceTree = "<group>"; };
 		B2EFFABC2ACBF69C007AF2EE /* StarRatedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarRatedView.swift; sourceTree = "<group>"; };
@@ -975,6 +985,18 @@
 			path = Popup;
 			sourceTree = "<group>";
 		};
+		B2EECB6D2B6A892900B328C1 /* LoginPopup */ = {
+			isa = PBXGroup;
+			children = (
+				B2EECB6E2B6A894200B328C1 /* LoginPopupRouter.swift */,
+				B2EECB6F2B6A894200B328C1 /* LoginPopupViewController.swift */,
+				B2EECB762B6A896600B328C1 /* LoginPopupViewHolder.swift */,
+				B2EECB702B6A894200B328C1 /* LoginPopupBuilder.swift */,
+				B2EECB712B6A894200B328C1 /* LoginPopupInteractor.swift */,
+			);
+			path = LoginPopup;
+			sourceTree = "<group>";
+		};
 		B2F169D42A3471EB008199D8 /* RootTabBar */ = {
 			isa = PBXGroup;
 			children = (
@@ -1304,6 +1326,7 @@
 				F097EF2F2A571DB000A7FB9C /* CommonWeb */,
 				F0C582BC2A55E81700DAD387 /* TermsOfUse */,
 				B2A529442A57F1E30010656A /* LogoutPopup */,
+				B2EECB6D2B6A892900B328C1 /* LoginPopup */,
 				F0EE10A62A4B387A00B8DF4F /* AccountSetting */,
 				BA00B73A2A46B95300BB3795 /* 3rdParty */,
 				BA00B7372A46B8A600BB3795 /* DesignSystem */,
@@ -1899,9 +1922,11 @@
 				BAED88302A24C3E600DA6257 /* RootViewController.swift in Sources */,
 				F01535472A45A70300A2A8F2 /* EventBannerCell.swift in Sources */,
 				BA50FD012A680AA900721782 /* ProductSearchRouter.swift in Sources */,
+				B2EECB752B6A894200B328C1 /* LoginPopupInteractor.swift in Sources */,
 				BA50FD032A680AA900721782 /* ProductSearchBuilder.swift in Sources */,
 				B248917C2B598412009D0FBF /* EventBannerDetailEntity.swift in Sources */,
 				B248916D2B443970009D0FBF /* EventImageCell.swift in Sources */,
+				B2EECB732B6A894200B328C1 /* LoginPopupViewController.swift in Sources */,
 				B2F169D82A3472D7008199D8 /* RootTabBarInteractor.swift in Sources */,
 				F033E8F82AC5C31700B021C8 /* FavoriteHomeViewController+ViewHolder.swift in Sources */,
 				F0DFBC962A59622A003F7660 /* MemberAPIService.swift in Sources */,
@@ -1928,6 +1953,7 @@
 				BA8322532AB7021D00D2E1EB /* ProductDetailEntity.swift in Sources */,
 				BABBB9662A69951700BC36A0 /* SearchBarViewDelegate.swift in Sources */,
 				BAE252262AC6DA0800405DEC /* ReviewEvaluationKind.swift in Sources */,
+				B2EECB722B6A894200B328C1 /* LoginPopupRouter.swift in Sources */,
 				F049E8C52A51CAE700E61199 /* ImageAssetKind+StoreTag.swift in Sources */,
 				F097EF372A571DD300A7FB9C /* CommonWebInteractor.swift in Sources */,
 				BA18C0A22A758FD0007D00BD /* BottomSheetPresentationController.swift in Sources */,
@@ -2047,6 +2073,7 @@
 				B2538B952A34551D00B7C3F0 /* LoggedInInteractor.swift in Sources */,
 				BAF8725F2AD41953001427DF /* ProductDetailReviewWriteCellDelegate.swift in Sources */,
 				BA4818CF2A59410B00BF9CAD /* UserAuthEntity.swift in Sources */,
+				B2EECB742B6A894200B328C1 /* LoginPopupBuilder.swift in Sources */,
 				B2EFFABB2ACBF680007AF2EE /* StarRatingView.swift in Sources */,
 				B28205052A346FDD00F9242F /* ProfileHomeInteractor.swift in Sources */,
 				F0D8FEBE2A3EDB6B000B530A /* UIColor+.swift in Sources */,
@@ -2096,6 +2123,7 @@
 				BA8924542A582ED200D1B097 /* EventTagBigView.swift in Sources */,
 				BA8924582A583AD400D1B097 /* ImageAssetKind+Icon.swift in Sources */,
 				B2F258192AAF03160022013E /* DetailReviewInteractor.swift in Sources */,
+				B2EECB772B6A896600B328C1 /* LoginPopupViewHolder.swift in Sources */,
 				F0A8A3B02A70053D00601DAE /* FilterType.swift in Sources */,
 				F06F40322B35EE2800897396 /* CurationAdCell.swift in Sources */,
 				BA87E3D72A45D40A000A9DEC /* GiftInformationView.swift in Sources */,

--- a/Pyonsnal-Color/Pyonsnal-Color/Common/Cell/ProductCell/ProductCell.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Common/Cell/ProductCell/ProductCell.swift
@@ -42,7 +42,7 @@ final class ProductCell: UICollectionViewCell {
             .sink { [weak self] _ in
                 guard let self, let product = self.product else { return }
                 
-                if let isGuest = UserInfoService.shared.isMemberGuest, !isGuest {
+                if let isGuest = UserInfoService.shared.isGuest, !isGuest {
                     let isSelected = !self.viewHolder.favoriteButton.isSelected
                     self.setFavoriteButtonSelected(isSelected: isSelected)
                 }

--- a/Pyonsnal-Color/Pyonsnal-Color/Common/Cell/ProductCell/ProductCell.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Common/Cell/ProductCell/ProductCell.swift
@@ -41,9 +41,12 @@ final class ProductCell: UICollectionViewCell {
             .throttle(for: 0.5, scheduler: RunLoop.main, latest: false)
             .sink { [weak self] _ in
                 guard let self, let product = self.product else { return }
-                let isSelected = !self.viewHolder.favoriteButton.isSelected
-                self.setFavoriteButtonSelected(isSelected: isSelected)
                 
+                if let isGuest = UserInfoService.shared.isMemberGuest, !isGuest {
+                    let isSelected = !self.viewHolder.favoriteButton.isSelected
+                    self.setFavoriteButtonSelected(isSelected: isSelected)
+                }
+
                 let action: FavoriteButtonAction = self.getFavoriteButtonSelected() ? .add : .delete
                 self.delegate?.didTapFavoriteButton(product: product, action: action)
             }.store(in: &cancellable)

--- a/Pyonsnal-Color/Pyonsnal-Color/Common/Popup/PopupView.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Common/Popup/PopupView.swift
@@ -62,12 +62,13 @@ final class PopupView: UIView {
 extension PopupView {
     
     enum Constant {
-            static let topBottomMargin: CGFloat = .spacing40
-            static let leftRightMargin: CGFloat = .spacing20
-            static let titleStackViewSpacing: CGFloat = .spacing8
-            static let buttonStackViewSpacing: CGFloat = .spacing16
-            static let buttonWidth: CGFloat = 151
-            static let buttonHeight: CGFloat = 52
+        static let topMargin: CGFloat = .spacing40
+        static let bottomMargin: CGFloat = .spacing20
+        static let leftRightMargin: CGFloat = .spacing20
+        static let titleStackViewSpacing: CGFloat = .spacing8
+        static let buttonStackViewSpacing: CGFloat = .spacing16
+        static let buttonWidth: CGFloat = 151
+        static let buttonHeight: CGFloat = 52
     }
     
     final class ViewHolder: ViewHolderable {
@@ -97,6 +98,8 @@ extension PopupView {
             let label = UILabel()
             label.font = .body2r
             label.textColor = .gray500
+            label.numberOfLines = 0
+            label.textAlignment = .center
             return label
         }()
         
@@ -142,12 +145,12 @@ extension PopupView {
             }
             
             textStackView.snp.makeConstraints {
-                $0.top.equalToSuperview().offset(Constant.topBottomMargin)
+                $0.top.lessThanOrEqualToSuperview().offset(Constant.topMargin)
                 $0.centerX.equalToSuperview()
             }
             
             buttonStackView.snp.makeConstraints {
-                $0.bottom.equalToSuperview().inset(Constant.topBottomMargin)
+                $0.bottom.equalToSuperview().inset(Constant.bottomMargin)
                 $0.centerX.equalToSuperview()
             }
             
@@ -156,7 +159,7 @@ extension PopupView {
             }
             
             descriptionLabel.snp.makeConstraints {
-                $0.height.equalTo(titleLabel.font.customLineHeight)
+                $0.height.greaterThanOrEqualTo(titleLabel.font.customLineHeight)
             }
             
             dismissButton.snp.makeConstraints {

--- a/Pyonsnal-Color/Pyonsnal-Color/Common/Popup/PopupView.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Common/Popup/PopupView.swift
@@ -24,6 +24,7 @@ final class PopupView: UIView {
         
         viewHolder.place(in: self)
         viewHolder.configureConstraints(for: self)
+        configureButtons()
     }
     
     required init?(coder: NSCoder) {

--- a/Pyonsnal-Color/Pyonsnal-Color/Common/Popup/PopupView.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Common/Popup/PopupView.swift
@@ -1,0 +1,173 @@
+//
+//  PopupView.swift
+//  Pyonsnal-Color
+//
+//  Created by 김인호 on 1/31/24.
+//
+
+import UIKit
+import Combine
+import SnapKit
+
+final class PopupView: UIView {
+    
+    // MARK: Property
+    private let viewHolder: ViewHolder = .init()
+    private var cancellable: Set<AnyCancellable> = .init()
+    
+    // MARK: Interface
+    weak var delegate: PopupViewDelegate?
+    
+    // MARK: Initializer
+    init() {
+        super.init(frame: .zero)
+        
+        viewHolder.place(in: self)
+        viewHolder.configureConstraints(for: self)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: Public Method
+    func configurePopup(
+        title: String,
+        description: String,
+        dismissText: String,
+        confirmText: String
+    ) {
+        viewHolder.titleLabel.text = title
+        viewHolder.descriptionLabel.text = description
+        viewHolder.dismissButton.setCustomFont(text: dismissText, color: .black, font: .body2m)
+        viewHolder.confirmButton.setCustomFont(text: confirmText, color: .red500, font: .body2m)
+    }
+    
+    // MARK: Private Method
+    private func configureButtons() {
+        viewHolder.dismissButton
+            .tapPublisher
+            .sink { [weak self] in
+                self?.delegate?.didTapDismissButton()
+            }.store(in: &cancellable)
+        
+        viewHolder.confirmButton
+            .tapPublisher
+            .sink { [weak self] in
+                self?.delegate?.didTapConfirmButton()
+            }.store(in: &cancellable)
+    }
+}
+
+extension PopupView {
+    
+    enum Constant {
+            static let topBottomMargin: CGFloat = .spacing40
+            static let leftRightMargin: CGFloat = .spacing20
+            static let titleStackViewSpacing: CGFloat = .spacing8
+            static let buttonStackViewSpacing: CGFloat = .spacing16
+            static let buttonWidth: CGFloat = 151
+            static let buttonHeight: CGFloat = 52
+    }
+    
+    final class ViewHolder: ViewHolderable {
+        private let mainPopupView: UIView = {
+            let view = UIView()
+            view.makeRounded(with: .spacing16)
+            view.backgroundColor = .white
+            return view
+        }()
+        
+        private let textStackView: UIStackView = {
+            let stackView = UIStackView()
+            stackView.axis = .vertical
+            stackView.spacing = Constant.titleStackViewSpacing
+            stackView.alignment = .center
+            return stackView
+        }()
+        
+        let titleLabel: UILabel = {
+            let label = UILabel()
+            label.font = .title1
+            label.textColor = .black
+            return label
+        }()
+        
+        let descriptionLabel: UILabel = {
+            let label = UILabel()
+            label.font = .body2r
+            label.textColor = .gray500
+            return label
+        }()
+        
+        private let buttonStackView: UIStackView = {
+            let stackView = UIStackView()
+            stackView.axis = .horizontal
+            stackView.spacing = Constant.buttonStackViewSpacing
+            stackView.alignment = .center
+            return stackView
+        }()
+        
+        let dismissButton: UIButton = {
+            let button = UIButton()
+            button.makeBorder(width: 1, color: UIColor.black.cgColor)
+            button.makeRounded(with: .spacing16)
+            return button
+        }()
+        
+        let confirmButton: UIButton = {
+            let button = UIButton()
+            button.makeBorder(width: 1, color: UIColor.black.cgColor)
+            button.makeRounded(with: .spacing16)
+            button.backgroundColor = .black
+            return button
+        }()
+        
+        func place(in view: UIView) {
+            view.addSubview(mainPopupView)
+            
+            mainPopupView.addSubview(textStackView)
+            mainPopupView.addSubview(buttonStackView)
+            
+            textStackView.addArrangedSubview(titleLabel)
+            textStackView.addArrangedSubview(descriptionLabel)
+            
+            buttonStackView.addArrangedSubview(dismissButton)
+            buttonStackView.addArrangedSubview(confirmButton)
+        }
+        
+        func configureConstraints(for view: UIView) {
+            mainPopupView.snp.makeConstraints {
+                $0.edges.equalTo(view)
+            }
+            
+            textStackView.snp.makeConstraints {
+                $0.top.equalToSuperview().offset(Constant.topBottomMargin)
+                $0.centerX.equalToSuperview()
+            }
+            
+            buttonStackView.snp.makeConstraints {
+                $0.bottom.equalToSuperview().inset(Constant.topBottomMargin)
+                $0.centerX.equalToSuperview()
+            }
+            
+            titleLabel.snp.makeConstraints {
+                $0.height.equalTo(titleLabel.font.customLineHeight)
+            }
+            
+            descriptionLabel.snp.makeConstraints {
+                $0.height.equalTo(titleLabel.font.customLineHeight)
+            }
+            
+            dismissButton.snp.makeConstraints {
+                $0.width.equalTo(Constant.buttonWidth)
+                $0.height.equalTo(Constant.buttonHeight)
+            }
+            
+            confirmButton.snp.makeConstraints {
+                $0.width.equalTo(Constant.buttonWidth)
+                $0.height.equalTo(Constant.buttonHeight)
+            }
+        }
+    }
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/Common/Popup/PopupView.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Common/Popup/PopupView.swift
@@ -11,15 +11,22 @@ import SnapKit
 
 final class PopupView: UIView {
     
+    enum State {
+        case normal
+        case reversed
+    }
+    
     // MARK: Property
     private let viewHolder: ViewHolder = .init()
     private var cancellable: Set<AnyCancellable> = .init()
+    private(set) var state: State
     
     // MARK: Interface
     weak var delegate: PopupViewDelegate?
     
     // MARK: Initializer
-    init() {
+    init(state: State) {
+        self.state = state
         super.init(frame: .zero)
         
         viewHolder.place(in: self)
@@ -46,17 +53,32 @@ final class PopupView: UIView {
     
     // MARK: Private Method
     private func configureButtons() {
-        viewHolder.dismissButton
-            .tapPublisher
-            .sink { [weak self] in
-                self?.delegate?.didTapDismissButton()
-            }.store(in: &cancellable)
-        
-        viewHolder.confirmButton
-            .tapPublisher
-            .sink { [weak self] in
-                self?.delegate?.didTapConfirmButton()
-            }.store(in: &cancellable)
+        switch state {
+        case .normal:
+            viewHolder.dismissButton
+                .tapPublisher
+                .sink { [weak self] in
+                    self?.delegate?.didTapDismissButton()
+                }.store(in: &cancellable)
+            
+            viewHolder.confirmButton
+                .tapPublisher
+                .sink { [weak self] in
+                    self?.delegate?.didTapConfirmButton()
+                }.store(in: &cancellable)
+        case .reversed:
+            viewHolder.dismissButton
+                .tapPublisher
+                .sink { [weak self] in
+                    self?.delegate?.didTapConfirmButton()
+                }.store(in: &cancellable)
+            
+            viewHolder.confirmButton
+                .tapPublisher
+                .sink { [weak self] in
+                    self?.delegate?.didTapDismissButton()
+                }.store(in: &cancellable)
+        }
     }
 }
 

--- a/Pyonsnal-Color/Pyonsnal-Color/Common/Popup/PopupViewDelegate.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Common/Popup/PopupViewDelegate.swift
@@ -1,0 +1,13 @@
+//
+//  PopupViewDelegate.swift
+//  Pyonsnal-Color
+//
+//  Created by 김인호 on 1/31/24.
+//
+
+import Foundation
+
+protocol PopupViewDelegate: AnyObject {
+    func didTapConfirmButton()
+    func didTapDismissButton()
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/Entity/Auth/UserAuthEntity.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Entity/Auth/UserAuthEntity.swift
@@ -10,5 +10,4 @@ struct UserAuthEntity: Codable {
     let isGuest: Bool
     let accessToken: String
     let refreshToken: String
-    let isGuest: Bool
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/Entity/Auth/UserAuthEntity.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Entity/Auth/UserAuthEntity.swift
@@ -10,4 +10,5 @@ struct UserAuthEntity: Codable {
     let isGuest: Bool
     let accessToken: String
     let refreshToken: String
+    let isGuest: Bool
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/Entity/Member/MemberInfoEntity.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Entity/Member/MemberInfoEntity.swift
@@ -15,5 +15,4 @@ struct MemberInfoEntity: Decodable {
     var memberId: Int
     var nickname: String
     var email: String
-    var isGuest: Bool
   }

--- a/Pyonsnal-Color/Pyonsnal-Color/Entity/Member/MemberInfoEntity.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Entity/Member/MemberInfoEntity.swift
@@ -15,4 +15,5 @@ struct MemberInfoEntity: Decodable {
     var memberId: Int
     var nickname: String
     var email: String
+    var isGuest: Bool
   }

--- a/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeBuilder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeBuilder.swift
@@ -17,11 +17,20 @@ final class EventHomeComponent: Component<EventHomeDependency>,
                                 EventDetailDependency,
                                 ProductDetailDependency,
                                 ProductFilterDependency,
-                                LoginPopupDependency {
+                                LoginPopupDependency,
+                                LoggedOutDependency {
+    var appleLoginService: AppleLoginService
+    var kakaoLoginService: KakaoLoginService
+    var authClient: AuthAPIService
+    var userAuthService: UserAuthService
     let productAPIService: ProductAPIService
     let favoriteAPIService: FavoriteAPIService
     
     override init(dependency: EventHomeDependency) {
+        self.appleLoginService = AppleLoginService()
+        self.kakaoLoginService = KakaoLoginService()
+        self.authClient = AuthAPIService(client: PyonsnalColorClient())
+        self.userAuthService = UserAuthService(keyChainService: KeyChainService.shared)
         self.productAPIService = dependency.productAPIService
         self.favoriteAPIService = dependency.favoriteAPIService
         super.init(dependency: dependency)
@@ -47,6 +56,8 @@ final class EventHomeBuilder: Builder<EventHomeDependency>, EventHomeBuildable {
         let productDetail: ProductDetailBuilder = .init(dependency: component)
         let productFilter: ProductFilterBuilder = .init(dependency: component)
         let loginPopup: LoginPopupBuilder = .init(dependency: component)
+        let loggedOut: LoggedOutBuilder = .init(dependency: component)
+        
         let interactor = EventHomeInteractor(
             presenter: viewController,
             dependency: dependency
@@ -60,7 +71,8 @@ final class EventHomeBuilder: Builder<EventHomeDependency>, EventHomeBuildable {
             eventDetailBuilder: eventDetailBuilder,
             productDetail: productDetail,
             productFilter: productFilter,
-            loginPopup: loginPopup
+            loginPopup: loginPopup,
+            loggedOut: loggedOut
         )
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeBuilder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeBuilder.swift
@@ -16,7 +16,8 @@ final class EventHomeComponent: Component<EventHomeDependency>,
                                 ProductSearchDependency,
                                 EventDetailDependency,
                                 ProductDetailDependency,
-                                ProductFilterDependency {
+                                ProductFilterDependency,
+                                LoginPopupDependency {
     let productAPIService: ProductAPIService
     let favoriteAPIService: FavoriteAPIService
     
@@ -45,17 +46,21 @@ final class EventHomeBuilder: Builder<EventHomeDependency>, EventHomeBuildable {
         let eventDetailBuilder = EventDetailBuilder(dependency: component)
         let productDetail: ProductDetailBuilder = .init(dependency: component)
         let productFilter: ProductFilterBuilder = .init(dependency: component)
+        let loginPopup: LoginPopupBuilder = .init(dependency: component)
         let interactor = EventHomeInteractor(
             presenter: viewController,
             dependency: dependency
         )
         let productSearch: ProductSearchBuilder = .init(dependency: component)
         interactor.listener = listener
-        return EventHomeRouter(interactor: interactor,
-                               viewController: viewController,
-                               productSearch: productSearch,
-                               eventDetailBuilder: eventDetailBuilder,
-                               productDetail: productDetail,
-                               productFilter: productFilter)
+        return EventHomeRouter(
+            interactor: interactor,
+            viewController: viewController,
+            productSearch: productSearch,
+            eventDetailBuilder: eventDetailBuilder,
+            productDetail: productDetail,
+            productFilter: productFilter,
+            loginPopup: loginPopup
+        )
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeInteractor.swift
@@ -134,7 +134,7 @@ final class EventHomeInteractor:
     }
     
     func didTapFavoriteButton(product: ProductDetailEntity, action: FavoriteButtonAction) {
-        if let isGuest = UserInfoService.shared.isMemberGuest, isGuest {
+        if let isGuest = UserInfoService.shared.isGuest, isGuest {
             router?.attachLoginPopup()
         } else {
             switch action {

--- a/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeInteractor.swift
@@ -19,6 +19,8 @@ protocol EventHomeRouting: ViewableRouting {
     func detachProductFilter()
     func attachLoginPopup()
     func detachLoginPopup()
+    func attachLoggedOut()
+    func detachLoggedOut(animated: Bool)
 }
 
 protocol EventHomePresentable: Presentable {
@@ -33,6 +35,7 @@ protocol EventHomePresentable: Presentable {
 }
 
 protocol EventHomeListener: AnyObject {
+    func routeToLoggedIn()
 }
 
 final class EventHomeInteractor:
@@ -314,6 +317,15 @@ final class EventHomeInteractor:
     
     func popupDidTapConfirm() {
         router?.detachLoginPopup()
-        // TODO: LoggedOut 이동
+        router?.attachLoggedOut()
+    }
+    
+    func routeToLoggedIn() {
+        router?.detachLoggedOut(animated: false)
+        listener?.routeToLoggedIn()
+    }
+    
+    func detachLoggedOut() {
+        router?.detachLoggedOut(animated: true)
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeInteractor.swift
@@ -17,6 +17,8 @@ protocol EventHomeRouting: ViewableRouting {
     func detachProductDetail()
     func attachProductFilter(of filter: FilterEntity)
     func detachProductFilter()
+    func attachLoginPopup()
+    func detachLoginPopup()
 }
 
 protocol EventHomePresentable: Presentable {
@@ -129,11 +131,15 @@ final class EventHomeInteractor:
     }
     
     func didTapFavoriteButton(product: ProductDetailEntity, action: FavoriteButtonAction) {
-        switch action {
-        case .add:
-            addFavorite(with: product)
-        case .delete:
-            deleteFavorite(with: product)
+        if let isGuest = UserInfoService.shared.isMemberGuest, isGuest {
+            router?.attachLoginPopup()
+        } else {
+            switch action {
+            case .add:
+                addFavorite(with: product)
+            case .delete:
+                deleteFavorite(with: product)
+            }
         }
     }
     
@@ -300,5 +306,14 @@ final class EventHomeInteractor:
         filterStateManager?.updateAllFilterItemState(to: false)
         filterStateManager?.deleteAllFilterList()
         filterStateManager?.setSortFilterDefaultText()
+    }
+    
+    func popupDidTapDismiss() {
+        router?.detachLoginPopup()
+    }
+    
+    func popupDidTapConfirm() {
+        router?.detachLoginPopup()
+        // TODO: LoggedOut 이동
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeRouter.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeRouter.swift
@@ -12,7 +12,8 @@ protocol EventHomeInteractable: Interactable,
                                 EventDetailListener,
                                 ProductDetailListener,
                                 ProductFilterListener,
-                                LoginPopupListener {
+                                LoginPopupListener,
+                                LoggedOutListener {
     var router: EventHomeRouting? { get set }
     var listener: EventHomeListener? { get set }
 }
@@ -29,12 +30,14 @@ final class EventHomeRouter: ViewableRouter<EventHomeInteractable, EventHomeView
     private let productDetail: ProductDetailBuildable
     private let productFilter: ProductFilterBuildable
     private let loginPopup: LoginPopupBuildable
+    private let loggedOut: LoggedOutBuildable
     
     private var productSearchRouting: ProductSearchRouting?
     private var eventDetailRouting: ViewableRouting?
     private var productDetailRouting: ProductDetailRouting?
     private var productFilterRouting: ProductFilterRouting?
     private var loginPopupRouting: LoginPopupRouting?
+    private var loggedOutRouting: LoggedOutRouting?
 
     init(
         interactor: EventHomeInteractable,
@@ -43,13 +46,15 @@ final class EventHomeRouter: ViewableRouter<EventHomeInteractable, EventHomeView
         eventDetailBuilder: EventDetailBuilder,
         productDetail: ProductDetailBuildable,
         productFilter: ProductFilterBuildable,
-        loginPopup: LoginPopupBuildable
+        loginPopup: LoginPopupBuildable,
+        loggedOut: LoggedOutBuildable
     ) {
         self.productSearch = productSearch
         self.eventDetailBuilder = eventDetailBuilder
         self.productDetail = productDetail
         self.productFilter = productFilter
         self.loginPopup = loginPopup
+        self.loggedOut = loggedOut
         super.init(interactor: interactor,
                    viewController: viewController)
         interactor.router = self
@@ -161,5 +166,28 @@ final class EventHomeRouter: ViewableRouter<EventHomeInteractable, EventHomeView
         viewControllable.uiviewController.dismiss(animated: false)
         detachChild(loginPopupRouting)
         self.loginPopupRouting = nil
+    }
+    
+    func attachLoggedOut() {
+        guard loggedOutRouting == nil else { return }
+        
+        let loggedOutRouter = loggedOut.build(withListener: interactor)
+        let viewController = loggedOutRouter.viewControllable.uiviewController
+        
+        loggedOutRouting = loggedOutRouter
+        attachChild(loggedOutRouter)
+        viewController.modalPresentationStyle = .overFullScreen
+        viewControllable.uiviewController.present(
+            viewController,
+            animated: true
+        )
+    }
+    
+    func detachLoggedOut(animated: Bool = true) {
+        guard let loggedOutRouting else { return }
+        
+        viewControllable.uiviewController.dismiss(animated: animated)
+        detachChild(loggedOutRouting)
+        self.loggedOutRouting = nil
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeRouter.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/EventHome/EventHomeRouter.swift
@@ -11,7 +11,8 @@ protocol EventHomeInteractable: Interactable,
                                 ProductSearchListener,
                                 EventDetailListener,
                                 ProductDetailListener,
-                                ProductFilterListener {
+                                ProductFilterListener,
+                                LoginPopupListener {
     var router: EventHomeRouting? { get set }
     var listener: EventHomeListener? { get set }
 }
@@ -27,11 +28,13 @@ final class EventHomeRouter: ViewableRouter<EventHomeInteractable, EventHomeView
     private let eventDetailBuilder: EventDetailBuilder
     private let productDetail: ProductDetailBuildable
     private let productFilter: ProductFilterBuildable
+    private let loginPopup: LoginPopupBuildable
     
     private var productSearchRouting: ProductSearchRouting?
     private var eventDetailRouting: ViewableRouting?
     private var productDetailRouting: ProductDetailRouting?
     private var productFilterRouting: ProductFilterRouting?
+    private var loginPopupRouting: LoginPopupRouting?
 
     init(
         interactor: EventHomeInteractable,
@@ -39,12 +42,14 @@ final class EventHomeRouter: ViewableRouter<EventHomeInteractable, EventHomeView
         productSearch: ProductSearchBuildable,
         eventDetailBuilder: EventDetailBuilder,
         productDetail: ProductDetailBuildable,
-        productFilter: ProductFilterBuildable
+        productFilter: ProductFilterBuildable,
+        loginPopup: LoginPopupBuildable
     ) {
         self.productSearch = productSearch
         self.eventDetailBuilder = eventDetailBuilder
         self.productDetail = productDetail
         self.productFilter = productFilter
+        self.loginPopup = loginPopup
         super.init(interactor: interactor,
                    viewController: viewController)
         interactor.router = self
@@ -133,5 +138,28 @@ final class EventHomeRouter: ViewableRouter<EventHomeInteractable, EventHomeView
         viewController.uiviewController.dismiss(animated: false)
         detachChild(productFilterRouting)
         self.productFilterRouting = nil
+    }
+    
+    func attachLoginPopup() {
+        guard loginPopupRouting == nil else { return }
+        
+        let loginPopupRouter = loginPopup.build(withListener: interactor)
+        let viewController = loginPopupRouter.viewControllable.uiviewController
+        
+        loginPopupRouting = loginPopupRouter
+        attachChild(loginPopupRouter)
+        viewController.modalPresentationStyle = .overFullScreen
+        viewControllable.uiviewController.present(
+            loginPopupRouter.viewControllable.uiviewController,
+            animated: false
+        )
+    }
+    
+    func detachLoginPopup() {
+        guard let loginPopupRouting else { return }
+        
+        viewControllable.uiviewController.dismiss(animated: false)
+        detachChild(loginPopupRouting)
+        self.loginPopupRouting = nil
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/FavoriteHome/FavoriteHomeInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/FavoriteHome/FavoriteHomeInteractor.swift
@@ -229,4 +229,7 @@ final class FavoriteHomeInteractor: PresentableInteractor<FavoriteHomePresentabl
             self.loadMoreEventProducts()
         }
     }
+    
+    func routeToLoggedIn() {
+    }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/LoggedOut/LoggedOutInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/LoggedOut/LoggedOutInteractor.swift
@@ -74,6 +74,7 @@ final class LoggedOutInteractor:
                     Log.d(message: "guest login success: \(userAuth)")
                     self?.setUserAuthEntity(userAuth: userAuth)
                     self?.listener?.routeToLoggedIn()
+                    UserInfoService.shared.configure()
                 }
             }.store(in: &cancellable)
     }
@@ -85,6 +86,7 @@ final class LoggedOutInteractor:
                     Log.d(message: "login success: \(userAuth)")
                     self?.setUserAuthEntity(userAuth: userAuth)
                     self?.listener?.routeToLoggedIn()
+                    UserInfoService.shared.configure()
                 }
             }.store(in: &cancellable)
     }

--- a/Pyonsnal-Color/Pyonsnal-Color/LoginPopup/LoginPopupBuilder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/LoginPopup/LoginPopupBuilder.swift
@@ -1,0 +1,39 @@
+//
+//  LoginPopupBuilder.swift
+//  Pyonsnal-Color
+//
+//  Created by 김인호 on 1/31/24.
+//
+
+import ModernRIBs
+
+protocol LoginPopupDependency: Dependency {
+    // TODO: Declare the set of dependencies required by this RIB, but cannot be
+    // created by this RIB.
+}
+
+final class LoginPopupComponent: Component<LoginPopupDependency> {
+
+    // TODO: Declare 'fileprivate' dependencies that are only used by this RIB.
+}
+
+// MARK: - Builder
+
+protocol LoginPopupBuildable: Buildable {
+    func build(withListener listener: LoginPopupListener) -> LoginPopupRouting
+}
+
+final class LoginPopupBuilder: Builder<LoginPopupDependency>, LoginPopupBuildable {
+
+    override init(dependency: LoginPopupDependency) {
+        super.init(dependency: dependency)
+    }
+
+    func build(withListener listener: LoginPopupListener) -> LoginPopupRouting {
+        let component = LoginPopupComponent(dependency: dependency)
+        let viewController = LoginPopupViewController()
+        let interactor = LoginPopupInteractor(presenter: viewController)
+        interactor.listener = listener
+        return LoginPopupRouter(interactor: interactor, viewController: viewController)
+    }
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/LoginPopup/LoginPopupInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/LoginPopup/LoginPopupInteractor.swift
@@ -1,0 +1,49 @@
+//
+//  LoginPopupInteractor.swift
+//  Pyonsnal-Color
+//
+//  Created by 김인호 on 1/31/24.
+//
+
+import ModernRIBs
+
+protocol LoginPopupRouting: ViewableRouting {
+}
+
+protocol LoginPopupPresentable: Presentable {
+    var listener: LoginPopupPresentableListener? { get set }
+}
+
+protocol LoginPopupListener: AnyObject {
+    func popupDidTapDismiss()
+    func popupDidTapConfirm()
+}
+
+final class LoginPopupInteractor: PresentableInteractor<LoginPopupPresentable>, 
+                                  LoginPopupInteractable,
+                                  LoginPopupPresentableListener {
+
+    weak var router: LoginPopupRouting?
+    weak var listener: LoginPopupListener?
+
+    override init(presenter: LoginPopupPresentable) {
+        super.init(presenter: presenter)
+        presenter.listener = self
+    }
+
+    override func didBecomeActive() {
+        super.didBecomeActive()
+    }
+
+    override func willResignActive() {
+        super.willResignActive()
+    }
+    
+    func popupDidTapDismiss() {
+        listener?.popupDidTapDismiss()
+    }
+    
+    func popupDidTapConfirm() {
+        listener?.popupDidTapConfirm()
+    }
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/LoginPopup/LoginPopupRouter.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/LoginPopup/LoginPopupRouter.swift
@@ -1,0 +1,26 @@
+//
+//  LoginPopupRouter.swift
+//  Pyonsnal-Color
+//
+//  Created by 김인호 on 1/31/24.
+//
+
+import ModernRIBs
+
+protocol LoginPopupInteractable: Interactable {
+    var router: LoginPopupRouting? { get set }
+    var listener: LoginPopupListener? { get set }
+}
+
+protocol LoginPopupViewControllable: ViewControllable {
+    // TODO: Declare methods the router invokes to manipulate the view hierarchy.
+}
+
+final class LoginPopupRouter: ViewableRouter<LoginPopupInteractable, LoginPopupViewControllable>, LoginPopupRouting {
+
+    // TODO: Constructor inject child builder protocols to allow building children.
+    override init(interactor: LoginPopupInteractable, viewController: LoginPopupViewControllable) {
+        super.init(interactor: interactor, viewController: viewController)
+        interactor.router = self
+    }
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/LoginPopup/LoginPopupViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/LoginPopup/LoginPopupViewController.swift
@@ -1,0 +1,59 @@
+//
+//  LoginPopupViewController.swift
+//  Pyonsnal-Color
+//
+//  Created by 김인호 on 1/31/24.
+//
+
+import ModernRIBs
+import UIKit
+
+protocol LoginPopupPresentableListener: AnyObject {
+    func popupDidTapDismiss()
+    func popupDidTapConfirm()
+}
+
+final class LoginPopupViewController: UIViewController, LoginPopupPresentable, LoginPopupViewControllable {
+
+    enum Constant {
+        static let popupTitle: String = "로그인이 필요한 기능입니다."
+        static let popupDescription: String = "지금 바로 편스널컬러의 회원이 되어 모든 기능을 이용해보세요!"
+        static let dismissText: String = "닫기"
+        static let confirmText: String = "로그인하기"
+    }
+    
+    // MARK: Property
+    private let viewHolder: ViewHolder = .init()
+    
+    weak var listener: LoginPopupPresentableListener?
+    
+    // MARK: Life Cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        viewHolder.place(in: view)
+        viewHolder.configureConstraints(for: view)
+        configurePopupView()
+    }
+    
+    private func configurePopupView() {
+        viewHolder.popupView.delegate = self
+        viewHolder.popupView.configurePopup(
+            title: Constant.popupTitle,
+            description: Constant.popupDescription,
+            dismissText: Constant.dismissText,
+            confirmText: Constant.confirmText
+        )
+    }
+}
+
+// MARK: - PopupViewDelegate
+extension LoginPopupViewController: PopupViewDelegate {
+    func didTapDismissButton() {
+        listener?.popupDidTapDismiss()
+    }
+    
+    func didTapConfirmButton() {
+        listener?.popupDidTapConfirm()
+    }
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/LoginPopup/LoginPopupViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/LoginPopup/LoginPopupViewController.swift
@@ -17,7 +17,7 @@ final class LoginPopupViewController: UIViewController, LoginPopupPresentable, L
 
     enum Constant {
         static let popupTitle: String = "로그인이 필요한 기능입니다."
-        static let popupDescription: String = "지금 바로 편스널컬러의 회원이 되어 모든 기능을 이용해보세요!"
+        static let popupDescription: String = "지금 바로 편스널컬러의 회원이 되어\n모든 기능을 이용해보세요!"
         static let dismissText: String = "닫기"
         static let confirmText: String = "로그인하기"
     }

--- a/Pyonsnal-Color/Pyonsnal-Color/LoginPopup/LoginPopupViewHolder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/LoginPopup/LoginPopupViewHolder.swift
@@ -1,0 +1,47 @@
+//
+//  LoginPopupViewHolder.swift
+//  Pyonsnal-Color
+//
+//  Created by 김인호 on 1/31/24.
+//
+
+import UIKit
+import SnapKit
+
+extension LoginPopupViewController {
+    final class ViewHolder: ViewHolderable {
+        
+        enum Constant {
+            static let popupHeight: CGFloat = 208
+            
+            static let backgroundColor: UIColor = .black.withAlphaComponent(0.4)
+        }
+        
+        private let backgroundView: UIView = {
+            let view = UIView()
+            view.backgroundColor = Constant.backgroundColor
+            return view
+        }()
+        
+        let popupView = PopupView()
+        
+        func place(in view: UIView) {
+            view.addSubview(backgroundView)
+            
+            backgroundView.addSubview(popupView)
+        }
+        
+        func configureConstraints(for view: UIView) {
+            backgroundView.snp.makeConstraints {
+                $0.edges.equalTo(view.safeAreaLayoutGuide)
+            }
+            
+            popupView.snp.makeConstraints {
+                $0.leading.equalToSuperview().offset(.spacing16)
+                $0.trailing.equalToSuperview().inset(.spacing16)
+                $0.centerY.equalToSuperview()
+                $0.height.equalTo(Constant.popupHeight)
+            }
+        }
+    }
+}

--- a/Pyonsnal-Color/Pyonsnal-Color/LoginPopup/LoginPopupViewHolder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/LoginPopup/LoginPopupViewHolder.swift
@@ -23,7 +23,7 @@ extension LoginPopupViewController {
             return view
         }()
         
-        let popupView = PopupView()
+        let popupView = PopupView(state: .normal)
         
         func place(in view: UIView) {
             view.addSubview(backgroundView)

--- a/Pyonsnal-Color/Pyonsnal-Color/LoginPopup/LoginPopupViewHolder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/LoginPopup/LoginPopupViewHolder.swift
@@ -33,7 +33,7 @@ extension LoginPopupViewController {
         
         func configureConstraints(for view: UIView) {
             backgroundView.snp.makeConstraints {
-                $0.edges.equalTo(view.safeAreaLayoutGuide)
+                $0.edges.equalTo(view)
             }
             
             popupView.snp.makeConstraints {

--- a/Pyonsnal-Color/Pyonsnal-Color/LogoutPopup/LogoutPopupInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/LogoutPopup/LogoutPopupInteractor.swift
@@ -50,12 +50,16 @@ final class LogoutPopupInteractor:
         super.willResignActive()
     }
     
-    func didTabDismissButton(_ text: String?) {
-        if let text, text == Text.dismiss {
-            listener?.popupDidTabDismissButton()
-        } else { // 회원 탈퇴
-            deleteAccount()
-        }
+    func didTapDismissButton() {
+        listener?.popupDidTabDismissButton()
+    }
+    
+    func didTapLogoutButton() {
+        logout()
+    }
+    
+    func didTapDeleteAccountButton() {
+        deleteAccount()
     }
     
     private func logout() {
@@ -86,14 +90,6 @@ final class LogoutPopupInteractor:
                     // Error handling
                 }
             }.store(in: &cancellable)
-    }
-    
-    func didTabConfirmButton(_ text: String?) {
-        if let text, text == Text.dismiss {
-            listener?.popupDidTabDismissButton()
-        } else { // 로그아웃
-            logout()
-        }
     }
     
     private func deleteToken() {

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductDetail/ProductDetailBuilder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductDetail/ProductDetailBuilder.swift
@@ -13,7 +13,8 @@ protocol ProductDetailDependency: Dependency {
 
 final class ProductDetailComponent: Component<ProductDetailDependency>, 
                                     StarRatingReviewDependency,
-                                    ProductFilterDependency {
+                                    ProductFilterDependency,
+                                    LoginPopupDependency {
 
     fileprivate let favoriteAPIService: FavoriteAPIService
     let client = PyonsnalColorClient()
@@ -49,15 +50,17 @@ final class ProductDetailBuilder: Builder<ProductDetailDependency>, ProductDetai
             dependency: dependency,
             product: product
         )
-        let starRatingReviewBuilder = StarRatingReviewBuilder(dependency: component)
+        let starRatingReview: StarRatingReviewBuilder = .init(dependency: component)
         let productFilter: ProductFilterBuilder = .init(dependency: component)
+        let loginPopup: LoginPopupBuilder = .init(dependency: component)
         
         interactor.listener = listener
         return ProductDetailRouter(
             interactor: interactor,
             viewController: viewController,
-            starRatingReviewBuilder: starRatingReviewBuilder,
-            productFilter: productFilter
+            starRatingReview: starRatingReview,
+            productFilter: productFilter,
+            loginPopup: loginPopup
         )
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductDetail/ProductDetailBuilder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductDetail/ProductDetailBuilder.swift
@@ -14,14 +14,21 @@ protocol ProductDetailDependency: Dependency {
 final class ProductDetailComponent: Component<ProductDetailDependency>, 
                                     StarRatingReviewDependency,
                                     ProductFilterDependency,
-                                    LoginPopupDependency {
+                                    LoginPopupDependency,
+                                    LoggedOutDependency {
 
     fileprivate let favoriteAPIService: FavoriteAPIService
     let client = PyonsnalColorClient()
     let userAuthService = UserAuthService(keyChainService: KeyChainService.shared)
+    let appleLoginService: AppleLoginService
+    let kakaoLoginService: KakaoLoginService
+    let authClient: AuthAPIService
     
     override init(dependency: ProductDetailDependency) {
         self.favoriteAPIService = FavoriteAPIService(client: client, userAuthService: userAuthService)
+        self.appleLoginService = AppleLoginService()
+        self.kakaoLoginService = KakaoLoginService()
+        self.authClient = AuthAPIService(client: client)
         super.init(dependency: dependency)
     }
 }
@@ -53,6 +60,7 @@ final class ProductDetailBuilder: Builder<ProductDetailDependency>, ProductDetai
         let starRatingReview: StarRatingReviewBuilder = .init(dependency: component)
         let productFilter: ProductFilterBuilder = .init(dependency: component)
         let loginPopup: LoginPopupBuilder = .init(dependency: component)
+        let loggedOut: LoggedOutBuilder = .init(dependency: component)
         
         interactor.listener = listener
         return ProductDetailRouter(
@@ -60,7 +68,8 @@ final class ProductDetailBuilder: Builder<ProductDetailDependency>, ProductDetai
             viewController: viewController,
             starRatingReview: starRatingReview,
             productFilter: productFilter,
-            loginPopup: loginPopup
+            loginPopup: loginPopup,
+            loggedOut: loggedOut
         )
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductDetail/ProductDetailInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductDetail/ProductDetailInteractor.swift
@@ -16,6 +16,8 @@ protocol ProductDetailRouting: ViewableRouting {
     func detachProductFilter()
     func attachLoginPopup()
     func detachLoginPopup()
+    func attachLoggedOut()
+    func detachLoggedOut(animated: Bool)
 }
 
 protocol ProductDetailPresentable: Presentable {
@@ -27,6 +29,7 @@ protocol ProductDetailPresentable: Presentable {
 
 protocol ProductDetailListener: AnyObject {
     func popProductDetail()
+    func routeToLoggedIn()
 }
 
 final class ProductDetailInteractor: PresentableInteractor<ProductDetailPresentable>,
@@ -393,5 +396,15 @@ final class ProductDetailInteractor: PresentableInteractor<ProductDetailPresenta
     
     func popupDidTapConfirm() {
         router?.detachLoginPopup()
+        router?.attachLoggedOut()
+    }
+    
+    func routeToLoggedIn() {
+        router?.detachLoggedOut(animated: false)
+        listener?.routeToLoggedIn()
+    }
+    
+    func detachLoggedOut() {
+        router?.detachLoggedOut(animated: true)
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductDetail/ProductDetailInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductDetail/ProductDetailInteractor.swift
@@ -79,7 +79,7 @@ final class ProductDetailInteractor: PresentableInteractor<ProductDetailPresenta
     }
     
     func addFavorite() {
-        if let isGuest = UserInfoService.shared.isMemberGuest, isGuest {
+        if let isGuest = UserInfoService.shared.isGuest, isGuest {
             router?.attachLoginPopup()
         } else {
             favoriteAPIService.addFavorite(
@@ -92,7 +92,7 @@ final class ProductDetailInteractor: PresentableInteractor<ProductDetailPresenta
     }
         
     func deleteFavorite() {
-        if let isGuest = UserInfoService.shared.isMemberGuest, isGuest {
+        if let isGuest = UserInfoService.shared.isGuest, isGuest {
             router?.attachLoginPopup()
         } else {
             favoriteAPIService.deleteFavorite(
@@ -174,7 +174,7 @@ final class ProductDetailInteractor: PresentableInteractor<ProductDetailPresenta
     }
     
     func reviewLikeButtonDidTap(review: ReviewEntity) {
-        if let isGuest = UserInfoService.shared.isMemberGuest, isGuest {
+        if let isGuest = UserInfoService.shared.isGuest, isGuest {
             router?.attachLoginPopup()
         } else {
             guard let memberID =  UserInfoService.shared.memberID,
@@ -186,7 +186,7 @@ final class ProductDetailInteractor: PresentableInteractor<ProductDetailPresenta
     }
     
     func reviewHateButtonDidTap(review: ReviewEntity) {
-        if let isGuest = UserInfoService.shared.isMemberGuest, isGuest {
+        if let isGuest = UserInfoService.shared.isGuest, isGuest {
             router?.attachLoginPopup()
         } else {
             guard let memberID =  UserInfoService.shared.memberID,
@@ -321,7 +321,7 @@ final class ProductDetailInteractor: PresentableInteractor<ProductDetailPresenta
     }
     
     func attachStarRatingReview() {
-        if let isGuest = UserInfoService.shared.isMemberGuest, isGuest {
+        if let isGuest = UserInfoService.shared.isGuest, isGuest {
             router?.attachLoginPopup()
         } else {
             logging(.writeReviewClick, parameter: [

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductDetail/ProductDetailInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductDetail/ProductDetailInteractor.swift
@@ -14,6 +14,8 @@ protocol ProductDetailRouting: ViewableRouting {
     func detachStarRatingReview()
     func attachProductFilter(of filter: FilterEntity)
     func detachProductFilter()
+    func attachLoginPopup()
+    func detachLoginPopup()
 }
 
 protocol ProductDetailPresentable: Presentable {
@@ -74,21 +76,29 @@ final class ProductDetailInteractor: PresentableInteractor<ProductDetailPresenta
     }
     
     func addFavorite() {
-        favoriteAPIService.addFavorite(
-            productId: product.id,
-            productType: product.productType
+        if let isGuest = UserInfoService.shared.isMemberGuest, isGuest {
+            router?.attachLoginPopup()
+        } else {
+            favoriteAPIService.addFavorite(
+                productId: product.id,
+                productType: product.productType
             ).sink { [weak self] response in
                 self?.presenter.setFavoriteState(isSelected: true)
             }.store(in: &cancellable)
         }
+    }
         
     func deleteFavorite() {
-        favoriteAPIService.deleteFavorite(
-            productId: product.id,
-            productType: product.productType
-        ).sink { [weak self] response in
-            self?.presenter.setFavoriteState(isSelected: false)
-        }.store(in: &cancellable)
+        if let isGuest = UserInfoService.shared.isMemberGuest, isGuest {
+            router?.attachLoginPopup()
+        } else {
+            favoriteAPIService.deleteFavorite(
+                productId: product.id,
+                productType: product.productType
+            ).sink { [weak self] response in
+                self?.presenter.setFavoriteState(isSelected: false)
+            }.store(in: &cancellable)
+        }
     }
     
     func refresh() {
@@ -161,19 +171,27 @@ final class ProductDetailInteractor: PresentableInteractor<ProductDetailPresenta
     }
     
     func reviewLikeButtonDidTap(review: ReviewEntity) {
-        guard let memberID =  UserInfoService.shared.memberID,
-              !review.likeCount.writerIds.contains(memberID) else {
-            return
+        if let isGuest = UserInfoService.shared.isMemberGuest, isGuest {
+            router?.attachLoginPopup()
+        } else {
+            guard let memberID =  UserInfoService.shared.memberID,
+                  !review.likeCount.writerIds.contains(memberID) else {
+                return
+            }
+            requestReviewLike(reviewID: review.reviewId, writerID: "\(memberID)")
         }
-        requestReviewLike(reviewID: review.reviewId, writerID: "\(memberID)")
     }
     
     func reviewHateButtonDidTap(review: ReviewEntity) {
-        guard let memberID =  UserInfoService.shared.memberID,
-              !review.hateCount.writerIds.contains(memberID) else {
-            return
+        if let isGuest = UserInfoService.shared.isMemberGuest, isGuest {
+            router?.attachLoginPopup()
+        } else {
+            guard let memberID =  UserInfoService.shared.memberID,
+                  !review.hateCount.writerIds.contains(memberID) else {
+                return
+            }
+            requestReviewHate(reviewID: review.reviewId, writerID: "\(memberID)")
         }
-        requestReviewHate(reviewID: review.reviewId, writerID: "\(memberID)")
     }
     
     func applyFilterItems(_ items: [FilterItemEntity], type: FilterType) {
@@ -300,10 +318,14 @@ final class ProductDetailInteractor: PresentableInteractor<ProductDetailPresenta
     }
     
     func attachStarRatingReview() {
-        logging(.writeReviewClick, parameter: [
-            .productName: product.name
-        ])
-        router?.attachStarRatingReview(with: product)
+        if let isGuest = UserInfoService.shared.isMemberGuest, isGuest {
+            router?.attachLoginPopup()
+        } else {
+            logging(.writeReviewClick, parameter: [
+                .productName: product.name
+            ])
+            router?.attachStarRatingReview(with: product)
+        }
     }
     
     func detachStarRatingReview() {
@@ -363,5 +385,13 @@ final class ProductDetailInteractor: PresentableInteractor<ProductDetailPresenta
         updatedReviews[reviewIndex] = updatedReview
         let updatedProductDetail = product.updateReviews(reviews: updatedReviews)
         reloadData(with: updatedProductDetail)
+    }
+    
+    func popupDidTapDismiss() {
+        router?.detachLoginPopup()
+    }
+    
+    func popupDidTapConfirm() {
+        router?.detachLoginPopup()
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductDetail/ProductDetailRouter.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductDetail/ProductDetailRouter.swift
@@ -10,7 +10,8 @@ import ModernRIBs
 protocol ProductDetailInteractable: Interactable, 
                                     StarRatingReviewListener,
                                     ProductFilterListener,
-                                    LoginPopupListener {
+                                    LoginPopupListener,
+                                    LoggedOutListener {
     var router: ProductDetailRouting? { get set }
     var listener: ProductDetailListener? { get set }
 }
@@ -29,6 +30,9 @@ final class ProductDetailRouter: ViewableRouter<ProductDetailInteractable, Produ
     
     private let loginPopup: LoginPopupBuildable
     private var loginPopupRouting: LoginPopupRouting?
+    
+    private let loggedOut: LoggedOutBuildable
+    private var loggedOutRouting: LoggedOutRouting?
 
     // TODO: Constructor inject child builder protocols to allow building children.
 
@@ -37,11 +41,13 @@ final class ProductDetailRouter: ViewableRouter<ProductDetailInteractable, Produ
         viewController: ProductDetailViewControllable,
         starRatingReview: StarRatingReviewBuildable,
         productFilter: ProductFilterBuildable,
-        loginPopup: LoginPopupBuildable
+        loginPopup: LoginPopupBuildable,
+        loggedOut: LoggedOutBuildable
     ) {
         self.starRatingReview = starRatingReview
         self.productFilter = productFilter
         self.loginPopup = loginPopup
+        self.loggedOut = loggedOut
         
         super.init(interactor: interactor, viewController: viewController)
         interactor.router = self
@@ -109,5 +115,28 @@ final class ProductDetailRouter: ViewableRouter<ProductDetailInteractable, Produ
         viewControllable.uiviewController.dismiss(animated: false)
         detachChild(loginPopupRouting)
         self.loginPopupRouting = nil
+    }
+    
+    func attachLoggedOut() {
+        guard loggedOutRouting == nil else { return }
+        
+        let loggedOutRouter = loggedOut.build(withListener: interactor)
+        let viewController = loggedOutRouter.viewControllable.uiviewController
+        
+        loggedOutRouting = loggedOutRouter
+        attachChild(loggedOutRouter)
+        viewController.modalPresentationStyle = .overFullScreen
+        viewControllable.uiviewController.present(
+            viewController,
+            animated: true
+        )
+    }
+    
+    func detachLoggedOut(animated: Bool = true) {
+        guard let loggedOutRouting else { return }
+        
+        viewControllable.uiviewController.dismiss(animated: animated)
+        detachChild(loggedOutRouting)
+        self.loggedOutRouting = nil
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeBuilder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeBuilder.swift
@@ -17,7 +17,8 @@ final class ProductHomeComponent: Component<ProductHomeDependency>,
                                   NotificationListDependency,
                                   ProductDetailDependency,
                                   ProductFilterDependency,
-                                  EventDetailDependency {
+                                  EventDetailDependency,
+                                  LoginPopupDependency {
     let productAPIService: ProductAPIService
     let favoriteAPIService: FavoriteAPIService
     
@@ -53,6 +54,7 @@ final class ProductHomeBuilder: Builder<ProductHomeDependency>, ProductHomeBuild
         let productDetail: ProductDetailBuilder = .init(dependency: component)
         let productFilter: ProductFilterBuilder = .init(dependency: component)
         let eventDetail: EventDetailBuilder = .init(dependency: component)
+        let loginPopup: LoginPopupBuilder = .init(dependency: component)
         
         interactor.listener = listener
         return ProductHomeRouter(
@@ -62,7 +64,8 @@ final class ProductHomeBuilder: Builder<ProductHomeDependency>, ProductHomeBuild
             notificationList: notificationList,
             productDetail: productDetail,
             productFilter: productFilter,
-            eventDetail: eventDetail
+            eventDetail: eventDetail,
+            loginPopup: loginPopup
         )
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeBuilder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeBuilder.swift
@@ -18,13 +18,23 @@ final class ProductHomeComponent: Component<ProductHomeDependency>,
                                   ProductDetailDependency,
                                   ProductFilterDependency,
                                   EventDetailDependency,
-                                  LoginPopupDependency {
+                                  LoginPopupDependency,
+                                  LoggedOutDependency {
+    var appleLoginService: AppleLoginService
+    var kakaoLoginService: KakaoLoginService
+    var authClient: AuthAPIService
+    var userAuthService: UserAuthService
     let productAPIService: ProductAPIService
     let favoriteAPIService: FavoriteAPIService
     
     override init(dependency: ProductHomeDependency) {
+        self.appleLoginService = AppleLoginService()
+        self.kakaoLoginService = KakaoLoginService()
+        self.authClient = AuthAPIService(client: PyonsnalColorClient())
+        self.userAuthService = UserAuthService(keyChainService: KeyChainService.shared)
         self.productAPIService = dependency.productAPIService
         self.favoriteAPIService = dependency.favoriteAPIService
+        
         super.init(dependency: dependency)
     }
 }
@@ -55,6 +65,7 @@ final class ProductHomeBuilder: Builder<ProductHomeDependency>, ProductHomeBuild
         let productFilter: ProductFilterBuilder = .init(dependency: component)
         let eventDetail: EventDetailBuilder = .init(dependency: component)
         let loginPopup: LoginPopupBuilder = .init(dependency: component)
+        let loggedOut: LoggedOutBuilder = .init(dependency: component)
         
         interactor.listener = listener
         return ProductHomeRouter(
@@ -65,7 +76,8 @@ final class ProductHomeBuilder: Builder<ProductHomeDependency>, ProductHomeBuild
             productDetail: productDetail,
             productFilter: productFilter,
             eventDetail: eventDetail,
-            loginPopup: loginPopup
+            loginPopup: loginPopup,
+            loggedOut: loggedOut
         )
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeInteractor.swift
@@ -162,7 +162,7 @@ final class ProductHomeInteractor: PresentableInteractor<ProductHomePresentable>
     }
     
     func didTapFavoriteButton(product: ProductDetailEntity, action: FavoriteButtonAction) {
-        if let isGuest = UserInfoService.shared.isMemberGuest, isGuest {
+        if let isGuest = UserInfoService.shared.isGuest, isGuest {
             router?.attachLoginPopup()
         } else {
             switch action {

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeInteractor.swift
@@ -21,6 +21,8 @@ protocol ProductHomeRouting: ViewableRouting {
     func detachEventDetail()
     func attachLoginPopup()
     func detachLoginPopup()
+    func attachLoggedOut()
+    func detachLoggedOut(animated: Bool)
 }
 
 protocol ProductHomePresentable: Presentable {
@@ -37,12 +39,12 @@ protocol ProductHomePresentable: Presentable {
 }
 
 protocol ProductHomeListener: AnyObject {
+    func routeToLoggedIn()
 }
 
-final class ProductHomeInteractor:
-    PresentableInteractor<ProductHomePresentable>,
-    ProductHomeInteractable,
-    ProductHomePresentableListener {
+final class ProductHomeInteractor: PresentableInteractor<ProductHomePresentable>,
+                                   ProductHomeInteractable,
+                                   ProductHomePresentableListener {
     
     weak var router: ProductHomeRouting?
     weak var listener: ProductHomeListener?
@@ -301,6 +303,15 @@ final class ProductHomeInteractor:
     
     func popupDidTapConfirm() {
         router?.detachLoginPopup()
-        // TODO: LoggedOut 리블렛 연결
+        router?.attachLoggedOut()
+    }
+    
+    func routeToLoggedIn() {
+        router?.detachLoggedOut(animated: false)
+        listener?.routeToLoggedIn()
+    }
+    
+    func detachLoggedOut() {
+        router?.detachLoggedOut(animated: true)
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeInteractor.swift
@@ -160,7 +160,7 @@ final class ProductHomeInteractor:
     }
     
     func didTapFavoriteButton(product: ProductDetailEntity, action: FavoriteButtonAction) {
-        if let isGuest = UserInfoService.shared.isMemberGuest {
+        if let isGuest = UserInfoService.shared.isMemberGuest, isGuest {
             router?.attachLoginPopup()
         } else {
             switch action {

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeInteractor.swift
@@ -19,6 +19,8 @@ protocol ProductHomeRouting: ViewableRouting {
     func detachProductFilter()
     func attachEventDetail(eventDetail: EventBannerDetailEntity)
     func detachEventDetail()
+    func attachLoginPopup()
+    func detachLoginPopup()
 }
 
 protocol ProductHomePresentable: Presentable {
@@ -158,11 +160,15 @@ final class ProductHomeInteractor:
     }
     
     func didTapFavoriteButton(product: ProductDetailEntity, action: FavoriteButtonAction) {
-        switch action {
-        case .add:
-            addFavorite(with: product)
-        case .delete:
-            deleteFavorite(with: product)
+        if let isGuest = UserInfoService.shared.isMemberGuest {
+            router?.attachLoginPopup()
+        } else {
+            switch action {
+            case .add:
+                addFavorite(with: product)
+            case .delete:
+                deleteFavorite(with: product)
+            }
         }
     }
     
@@ -287,5 +293,14 @@ final class ProductHomeInteractor:
         filterStateManager?.updateAllFilterItemState(to: false)
         filterStateManager?.deleteAllFilterList()
         filterStateManager?.setSortFilterDefaultText()
+    }
+    
+    func popupDidTapDismiss() {
+        router?.detachLoginPopup()
+    }
+    
+    func popupDidTapConfirm() {
+        router?.detachLoginPopup()
+        // TODO: LoggedOut 리블렛 연결
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeRouter.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeRouter.swift
@@ -7,7 +7,14 @@
 
 import ModernRIBs
 
-protocol ProductHomeInteractable: Interactable, ProductSearchListener, NotificationListListener, ProductDetailListener, ProductFilterListener, EventDetailListener, LoginPopupListener {
+protocol ProductHomeInteractable: Interactable,
+                                  ProductSearchListener,
+                                  NotificationListListener,
+                                  ProductDetailListener,
+                                  ProductFilterListener,
+                                  EventDetailListener,
+                                  LoginPopupListener,
+                                  LoggedOutListener {
     var router: ProductHomeRouting? { get set }
     var listener: ProductHomeListener? { get set }
 }
@@ -25,6 +32,7 @@ final class ProductHomeRouter:
     private let productFilter: ProductFilterBuildable
     private let eventDetail: EventDetailBuildable
     private let loginPopup: LoginPopupBuildable
+    private let loggedOut: LoggedOutBuildable
     
     private var productSearchRouting: ProductSearchRouting?
     private var notificationListRouting: NotificationListRouting?
@@ -32,6 +40,7 @@ final class ProductHomeRouter:
     private var productFilterRouting: ProductFilterRouting?
     private var eventDetailRouting: EventDetailRouting?
     private var loginPopupRouting: LoginPopupRouting?
+    private var loggedOutRouting: LoggedOutRouting?
     
     init(
         interactor: ProductHomeInteractable,
@@ -41,7 +50,8 @@ final class ProductHomeRouter:
         productDetail: ProductDetailBuildable,
         productFilter: ProductFilterBuildable,
         eventDetail: EventDetailBuildable,
-        loginPopup: LoginPopupBuildable
+        loginPopup: LoginPopupBuildable,
+        loggedOut: LoggedOutBuildable
     ) {
         self.productSearch = productSearch
         self.notificationList = notificationList
@@ -49,6 +59,7 @@ final class ProductHomeRouter:
         self.productFilter = productFilter
         self.eventDetail = eventDetail
         self.loginPopup = loginPopup
+        self.loggedOut = loggedOut
         super.init(interactor: interactor, viewController: viewController)
         
         interactor.router = self
@@ -171,7 +182,7 @@ final class ProductHomeRouter:
         attachChild(loginPopupRouter)
         viewController.modalPresentationStyle = .overFullScreen
         viewControllable.uiviewController.present(
-            loginPopupRouter.viewControllable.uiviewController,
+            viewController,
             animated: false
         )
     }
@@ -182,5 +193,28 @@ final class ProductHomeRouter:
         viewControllable.uiviewController.dismiss(animated: false)
         detachChild(loginPopupRouting)
         self.loginPopupRouting = nil
+    }
+    
+    func attachLoggedOut() {
+        guard loggedOutRouting == nil else { return }
+        
+        let loggedOutRouter = loggedOut.build(withListener: interactor)
+        let viewController = loggedOutRouter.viewControllable.uiviewController
+        
+        loggedOutRouting = loggedOutRouter
+        attachChild(loggedOutRouter)
+        viewController.modalPresentationStyle = .overFullScreen
+        viewControllable.uiviewController.present(
+            viewController,
+            animated: true
+        )
+    }
+    
+    func detachLoggedOut(animated: Bool = true) {
+        guard let loggedOutRouting else { return }
+        
+        viewControllable.uiviewController.dismiss(animated: animated)
+        detachChild(loggedOutRouting)
+        self.loggedOutRouting = nil
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeRouter.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductHome/ProductHomeRouter.swift
@@ -7,7 +7,7 @@
 
 import ModernRIBs
 
-protocol ProductHomeInteractable: Interactable, ProductSearchListener, NotificationListListener, ProductDetailListener, ProductFilterListener, EventDetailListener {
+protocol ProductHomeInteractable: Interactable, ProductSearchListener, NotificationListListener, ProductDetailListener, ProductFilterListener, EventDetailListener, LoginPopupListener {
     var router: ProductHomeRouting? { get set }
     var listener: ProductHomeListener? { get set }
 }
@@ -24,12 +24,14 @@ final class ProductHomeRouter:
     private let productDetail: ProductDetailBuildable
     private let productFilter: ProductFilterBuildable
     private let eventDetail: EventDetailBuildable
+    private let loginPopup: LoginPopupBuildable
     
     private var productSearchRouting: ProductSearchRouting?
     private var notificationListRouting: NotificationListRouting?
     private var productDetailRouting: ProductDetailRouting?
     private var productFilterRouting: ProductFilterRouting?
     private var eventDetailRouting: EventDetailRouting?
+    private var loginPopupRouting: LoginPopupRouting?
     
     init(
         interactor: ProductHomeInteractable,
@@ -38,13 +40,15 @@ final class ProductHomeRouter:
         notificationList: NotificationListBuildable,
         productDetail: ProductDetailBuildable,
         productFilter: ProductFilterBuildable,
-        eventDetail: EventDetailBuildable
+        eventDetail: EventDetailBuildable,
+        loginPopup: LoginPopupBuildable
     ) {
         self.productSearch = productSearch
         self.notificationList = notificationList
         self.productDetail = productDetail
         self.productFilter = productFilter
         self.eventDetail = eventDetail
+        self.loginPopup = loginPopup
         super.init(interactor: interactor, viewController: viewController)
         
         interactor.router = self
@@ -155,5 +159,28 @@ final class ProductHomeRouter:
         viewController.popViewController(animated: true)
         detachChild(eventDetailRouting)
         self.eventDetailRouting = nil
+    }
+    
+    func attachLoginPopup() {
+        guard loginPopupRouting == nil else { return }
+        
+        let loginPopupRouter = loginPopup.build(withListener: interactor)
+        let viewController = loginPopupRouter.viewControllable.uiviewController
+        
+        loginPopupRouting = loginPopupRouter
+        attachChild(loginPopupRouter)
+        viewController.modalPresentationStyle = .overFullScreen
+        viewControllable.uiviewController.present(
+            loginPopupRouter.viewControllable.uiviewController,
+            animated: false
+        )
+    }
+    
+    func detachLoginPopup() {
+        guard let loginPopupRouting else { return }
+        
+        viewControllable.uiviewController.dismiss(animated: false)
+        detachChild(loginPopupRouting)
+        self.loginPopupRouting = nil
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductSearch/ProductSearchBuilder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductSearch/ProductSearchBuilder.swift
@@ -16,10 +16,19 @@ final class ProductSearchComponent: Component<ProductSearchDependency>,
                                     ProductSearchSortBottomSheetDependency,
                                     ProductFilterDependency,
                                     ProductDetailDependency,
-                                    LoginPopupDependency {
+                                    LoginPopupDependency,
+                                    LoggedOutDependency {
+    var appleLoginService: AppleLoginService
+    var kakaoLoginService: KakaoLoginService
+    var authClient: AuthAPIService
+    var userAuthService: UserAuthService
     var productAPIService: ProductAPIService
     
     override init(dependency: ProductSearchDependency) {
+        self.appleLoginService = AppleLoginService()
+        self.kakaoLoginService = KakaoLoginService()
+        self.authClient = AuthAPIService(client: PyonsnalColorClient())
+        self.userAuthService = UserAuthService(keyChainService: KeyChainService.shared)
         self.productAPIService = dependency.productAPIService
         
         super.init(dependency: dependency)
@@ -49,6 +58,7 @@ final class ProductSearchBuilder: Builder<ProductSearchDependency>, ProductSearc
         let productFilter: ProductFilterBuilder = .init(dependency: component)
         let productDetail: ProductDetailBuilder = .init(dependency: component)
         let loginPopup: LoginPopupBuilder = .init(dependency: component)
+        let loggedOut: LoggedOutBuilder = .init(dependency: component)
         
         interactor.listener = listener
         return ProductSearchRouter(
@@ -57,7 +67,8 @@ final class ProductSearchBuilder: Builder<ProductSearchDependency>, ProductSearc
             productSearchSortBottomSheet: prodcutSearchSortBottomSheet,
             productFilter: productFilter,
             productDetail: productDetail,
-            loginPopup: loginPopup
+            loginPopup: loginPopup,
+            loggedOut: loggedOut
         )
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductSearch/ProductSearchBuilder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductSearch/ProductSearchBuilder.swift
@@ -15,7 +15,8 @@ protocol ProductSearchDependency: Dependency {
 final class ProductSearchComponent: Component<ProductSearchDependency>,
                                     ProductSearchSortBottomSheetDependency,
                                     ProductFilterDependency,
-                                    ProductDetailDependency {
+                                    ProductDetailDependency,
+                                    LoginPopupDependency {
     var productAPIService: ProductAPIService
     
     override init(dependency: ProductSearchDependency) {
@@ -47,6 +48,7 @@ final class ProductSearchBuilder: Builder<ProductSearchDependency>, ProductSearc
         )
         let productFilter: ProductFilterBuilder = .init(dependency: component)
         let productDetail: ProductDetailBuilder = .init(dependency: component)
+        let loginPopup: LoginPopupBuilder = .init(dependency: component)
         
         interactor.listener = listener
         return ProductSearchRouter(
@@ -54,7 +56,8 @@ final class ProductSearchBuilder: Builder<ProductSearchDependency>, ProductSearc
             viewController: viewController,
             productSearchSortBottomSheet: prodcutSearchSortBottomSheet,
             productFilter: productFilter,
-            productDetail: productDetail
+            productDetail: productDetail,
+            loginPopup: loginPopup
         )
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductSearch/ProductSearchInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductSearch/ProductSearchInteractor.swift
@@ -16,6 +16,8 @@ protocol ProductSearchRouting: ViewableRouting {
     func detachProductFilter()
     func attachProductDetail(with product: ProductDetailEntity)
     func detachProductDetail()
+    func attachLoginPopup()
+    func detachLoginPopup()
 }
 
 protocol ProductSearchPresentable: Presentable {
@@ -176,11 +178,15 @@ final class ProductSearchInteractor: PresentableInteractor<ProductSearchPresenta
     }
     
     func didTapFavoriteButton(product: ProductDetailEntity, action: FavoriteButtonAction) {
-        switch action {
-        case .add:
-            addFavorite(with: product)
-        case .delete:
-            deleteFavorite(with: product)
+        if let isGuest = UserInfoService.shared.isMemberGuest, isGuest {
+            router?.attachLoginPopup()
+        } else {
+            switch action {
+            case .add:
+                addFavorite(with: product)
+            case .delete:
+                deleteFavorite(with: product)
+            }
         }
     }
     
@@ -289,4 +295,13 @@ final class ProductSearchInteractor: PresentableInteractor<ProductSearchPresenta
         requestSort(filterItem: item)
         router?.detachProductFilter()
     }
+    
+    func popupDidTapDismiss() {
+        router?.detachLoginPopup()
+    }
+    
+    func popupDidTapConfirm() {
+        router?.detachLoginPopup()
+    }
+
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductSearch/ProductSearchInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductSearch/ProductSearchInteractor.swift
@@ -181,7 +181,7 @@ final class ProductSearchInteractor: PresentableInteractor<ProductSearchPresenta
     }
     
     func didTapFavoriteButton(product: ProductDetailEntity, action: FavoriteButtonAction) {
-        if let isGuest = UserInfoService.shared.isMemberGuest, isGuest {
+        if let isGuest = UserInfoService.shared.isGuest, isGuest {
             router?.attachLoginPopup()
         } else {
             switch action {

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductSearch/ProductSearchInteractor.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductSearch/ProductSearchInteractor.swift
@@ -18,6 +18,8 @@ protocol ProductSearchRouting: ViewableRouting {
     func detachProductDetail()
     func attachLoginPopup()
     func detachLoginPopup()
+    func attachLoggedOut()
+    func detachLoggedOut(animated: Bool)
 }
 
 protocol ProductSearchPresentable: Presentable {
@@ -29,6 +31,7 @@ protocol ProductSearchPresentable: Presentable {
 protocol ProductSearchListener: AnyObject {
     // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
     func popProductSearch()
+    func routeToLoggedIn()
 }
 
 final class ProductSearchInteractor: PresentableInteractor<ProductSearchPresentable>, ProductSearchInteractable, ProductSearchPresentableListener {
@@ -302,6 +305,15 @@ final class ProductSearchInteractor: PresentableInteractor<ProductSearchPresenta
     
     func popupDidTapConfirm() {
         router?.detachLoginPopup()
+        router?.attachLoggedOut()
     }
 
+    func routeToLoggedIn() {
+        router?.detachLoggedOut(animated: false)
+        listener?.routeToLoggedIn()
+    }
+    
+    func detachLoggedOut() {
+        router?.detachLoggedOut(animated: true)
+    }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductSearch/ProductSearchRouter.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductSearch/ProductSearchRouter.swift
@@ -7,7 +7,7 @@
 
 import ModernRIBs
 
-protocol ProductSearchInteractable: Interactable, ProductSearchSortBottomSheetListener, ProductFilterListener, ProductDetailListener, LoginPopupListener {
+protocol ProductSearchInteractable: Interactable, ProductSearchSortBottomSheetListener, ProductFilterListener, ProductDetailListener, LoginPopupListener, LoggedOutListener {
     var router: ProductSearchRouting? { get set }
     var listener: ProductSearchListener? { get set }
 }
@@ -29,6 +29,9 @@ final class ProductSearchRouter: ViewableRouter<ProductSearchInteractable, Produ
     
     private let loginPopup: LoginPopupBuildable
     private var loginPopupRouting: LoginPopupRouting?
+    
+    private let loggedOut: LoggedOutBuildable
+    private var loggedOutRouting: LoggedOutRouting?
 
     init(
         interactor: ProductSearchInteractable,
@@ -36,12 +39,14 @@ final class ProductSearchRouter: ViewableRouter<ProductSearchInteractable, Produ
         productSearchSortBottomSheet: ProductSearchSortBottomSheetBuildable,
         productFilter: ProductFilterBuildable,
         productDetail: ProductDetailBuildable,
-        loginPopup: LoginPopupBuildable
+        loginPopup: LoginPopupBuildable,
+        loggedOut: LoggedOutBuildable
     ) {
         self.productSearchSortBottomSheet = productSearchSortBottomSheet
         self.productFilter = productFilter
         self.productDetail = productDetail
         self.loginPopup = loginPopup
+        self.loggedOut = loggedOut
         
         super.init(interactor: interactor, viewController: viewController)
         interactor.router = self
@@ -128,5 +133,28 @@ final class ProductSearchRouter: ViewableRouter<ProductSearchInteractable, Produ
         viewControllable.uiviewController.dismiss(animated: false)
         detachChild(loginPopupRouting)
         self.loginPopupRouting = nil
+    }
+    
+    func attachLoggedOut() {
+        guard loggedOutRouting == nil else { return }
+        
+        let loggedOutRouter = loggedOut.build(withListener: interactor)
+        let viewController = loggedOutRouter.viewControllable.uiviewController
+        
+        loggedOutRouting = loggedOutRouter
+        attachChild(loggedOutRouter)
+        viewController.modalPresentationStyle = .overFullScreen
+        viewControllable.uiviewController.present(
+            viewController,
+            animated: true
+        )
+    }
+    
+    func detachLoggedOut(animated: Bool = true) {
+        guard let loggedOutRouting else { return }
+        
+        viewControllable.uiviewController.dismiss(animated: animated)
+        detachChild(loggedOutRouting)
+        self.loggedOutRouting = nil
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ProductSearch/ProductSearchRouter.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ProductSearch/ProductSearchRouter.swift
@@ -7,7 +7,7 @@
 
 import ModernRIBs
 
-protocol ProductSearchInteractable: Interactable, ProductSearchSortBottomSheetListener, ProductFilterListener, ProductDetailListener {
+protocol ProductSearchInteractable: Interactable, ProductSearchSortBottomSheetListener, ProductFilterListener, ProductDetailListener, LoginPopupListener {
     var router: ProductSearchRouting? { get set }
     var listener: ProductSearchListener? { get set }
 }
@@ -26,17 +26,22 @@ final class ProductSearchRouter: ViewableRouter<ProductSearchInteractable, Produ
     
     private let productDetail: ProductDetailBuildable
     private var productDetailRouting: ProductDetailRouting?
+    
+    private let loginPopup: LoginPopupBuildable
+    private var loginPopupRouting: LoginPopupRouting?
 
     init(
         interactor: ProductSearchInteractable,
         viewController: ProductSearchViewControllable,
         productSearchSortBottomSheet: ProductSearchSortBottomSheetBuildable,
         productFilter: ProductFilterBuildable,
-        productDetail: ProductDetailBuildable
+        productDetail: ProductDetailBuildable,
+        loginPopup: LoginPopupBuildable
     ) {
         self.productSearchSortBottomSheet = productSearchSortBottomSheet
         self.productFilter = productFilter
         self.productDetail = productDetail
+        self.loginPopup = loginPopup
         
         super.init(interactor: interactor, viewController: viewController)
         interactor.router = self
@@ -100,5 +105,28 @@ final class ProductSearchRouter: ViewableRouter<ProductSearchInteractable, Produ
         viewController.popViewController(animated: true)
         detachChild(productDetailRouting)
         self.productDetailRouting = nil
+    }
+    
+    func attachLoginPopup() {
+        guard loginPopupRouting == nil else { return }
+        
+        let loginPopupRouter = loginPopup.build(withListener: interactor)
+        let viewController = loginPopupRouter.viewControllable.uiviewController
+        
+        loginPopupRouting = loginPopupRouter
+        attachChild(loginPopupRouter)
+        viewController.modalPresentationStyle = .overFullScreen
+        viewControllable.uiviewController.present(
+            loginPopupRouter.viewControllable.uiviewController,
+            animated: false
+        )
+    }
+    
+    func detachLoginPopup() {
+        guard let loginPopupRouting else { return }
+        
+        viewControllable.uiviewController.dismiss(animated: false)
+        detachChild(loginPopupRouting)
+        self.loginPopupRouting = nil
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ReviewPopup/ReviewPopupViewController.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ReviewPopup/ReviewPopupViewController.swift
@@ -40,8 +40,7 @@ final class ReviewPopupViewController: UIViewController, ReviewPopupPresentable,
     convenience init(isApply: Bool) {
         self.init()
         
-        configureText(isApply: isApply)
-        configureButtonAction(isApply: isApply)
+        configurePopupView(isApply: isApply)
     }
     
     override func viewDidLoad() {
@@ -52,75 +51,47 @@ final class ReviewPopupViewController: UIViewController, ReviewPopupPresentable,
         configureView()
     }
     
-    private func configureText(isApply: Bool) {
+    private func configurePopupView(isApply: Bool) {
         if isApply {
-            viewHolder.titleLabel.text = Text.Apply.title
-            viewHolder.descriptionLabel.text = Text.Apply.description
-            viewHolder.dismissButton.setCustomFont(
-                text: Text.Apply.dismiss,
-                color: .black,
-                font: .body2m
-            )
-            viewHolder.confirmButton.setCustomFont(
-                text: Text.Apply.confirm,
-                color: .red500,
-                font: .body2m
+            viewHolder.popupView = .init(state: .normal)
+            viewHolder.popupView.delegate = self
+            viewHolder.popupView.configurePopup(
+                title: Text.Apply.title,
+                description: Text.Apply.description,
+                dismissText: Text.Apply.dismiss,
+                confirmText: Text.Apply.confirm
             )
         } else {
-            viewHolder.titleLabel.text = Text.Cancel.title
-            viewHolder.descriptionLabel.text = Text.Cancel.description
-            viewHolder.dismissButton.setCustomFont(
-                text: Text.Cancel.dismiss,
-                color: .black,
-                font: .body2m
+            viewHolder.popupView = .init(state: .reversed)
+            viewHolder.popupView.delegate = self
+            viewHolder.popupView.configurePopup(
+                title: Text.Cancel.title,
+                description: Text.Cancel.description,
+                dismissText: Text.Cancel.confirm,
+                confirmText: Text.Cancel.dismiss
             )
-            viewHolder.confirmButton.setCustomFont(
-                text: Text.Cancel.confirm,
-                color: .red500,
-                font: .body2m
-            )
-        }
-    }
-    
-    private func configureButtonAction(isApply: Bool) {
-        if isApply {
-            viewHolder.dismissButton
-                .tapPublisher
-                .sink { [weak self] in
-                    self?.didTapDismissButton()
-                }.store(in: &cancellable)
-            viewHolder.confirmButton
-                .tapPublisher
-                .sink { [weak self] in
-                    self?.didTapApplyButton()
-                }.store(in: &cancellable)
-        } else {
-            viewHolder.dismissButton
-                .tapPublisher
-                .sink { [weak self] in
-                    self?.didTapBackButton()
-                }.store(in: &cancellable)
-            viewHolder.confirmButton
-                .tapPublisher
-                .sink { [weak self] in
-                    self?.didTapDismissButton()
-                }.store(in: &cancellable)
         }
     }
     
     private func configureView() {
-        view.backgroundColor = .black.withAlphaComponent(0.7)
+        view.backgroundColor = .black.withAlphaComponent(0.4)
+    }
+}
+
+extension ReviewPopupViewController: PopupViewDelegate {
+    func didTapDismissButton() {
+        if viewHolder.popupView.state == .normal {
+            listener?.didTapDismissButton()
+        } else {
+            listener?.didTapBackButton()
+        }
     }
     
-    private func didTapDismissButton() {
-        listener?.didTapDismissButton()
-    }
-    
-    private func didTapApplyButton() {
-        listener?.didTapApplyButton()
-    }
-    
-    private func didTapBackButton() {
-        listener?.didTapBackButton()
+    func didTapConfirmButton() {
+        if viewHolder.popupView.state == .normal {
+            listener?.didTapApplyButton()
+        } else {
+            listener?.didTapDismissButton()
+        }
     }
 }

--- a/Pyonsnal-Color/Pyonsnal-Color/ReviewPopup/ReviewPopupViewHolder.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/ReviewPopup/ReviewPopupViewHolder.swift
@@ -10,124 +10,38 @@ import SnapKit
 
 extension ReviewPopupViewController {
     final class ViewHolder: ViewHolderable {
+        
         enum Constant {
                 static let topBottomMargin: CGFloat = .spacing40
                 static let leftRightMargin: CGFloat = .spacing20
                 static let titleStackViewSpacing: CGFloat = .spacing8
                 static let buttonStackViewSpacing: CGFloat = .spacing16
                 static let popupWidth: CGFloat = 358
-                static let popupHeight: CGFloat = 228
+                static let popupHeight: CGFloat = 208
                 static let buttonWidth: CGFloat = 151
                 static let buttonHeight: CGFloat = 52
         }
         
         private let containerView: UIView = .init(frame: .zero)
         
-        private let mainPopupView: UIView = {
-            let view = UIView()
-            view.makeRounded(with: .spacing16)
-            view.backgroundColor = .white
-            return view
-        }()
-        
-        private let textStackView: UIStackView = {
-            let stackView = UIStackView()
-            stackView.axis = .vertical
-            stackView.spacing = Constant.titleStackViewSpacing
-            stackView.alignment = .center
-            return stackView
-        }()
-        
-        let titleLabel: UILabel = {
-            let label = UILabel()
-            label.font = .title1
-            label.textColor = .black
-            return label
-        }()
-        
-        let descriptionLabel: UILabel = {
-            let label = UILabel()
-            label.font = .body2r
-            label.textColor = .gray500
-            return label
-        }()
-        
-        private let buttonStackView: UIStackView = {
-            let stackView = UIStackView()
-            stackView.axis = .horizontal
-            stackView.spacing = Constant.buttonStackViewSpacing
-            stackView.alignment = .center
-            return stackView
-        }()
-        
-        let dismissButton: UIButton = {
-            let button = UIButton()
-            button.makeBorder(width: 1, color: UIColor.black.cgColor)
-            button.makeRounded(with: .spacing16)
-            return button
-        }()
-        
-        let confirmButton: UIButton = {
-            let button = UIButton()
-            button.makeBorder(width: 1, color: UIColor.black.cgColor)
-            button.makeRounded(with: .spacing16)
-            button.backgroundColor = .black
-            return button
-        }()
+        var popupView = PopupView(state: .normal)
         
         func place(in view: UIView) {
             view.addSubview(containerView)
             
-            containerView.addSubview(mainPopupView)
-            
-            mainPopupView.addSubview(textStackView)
-            mainPopupView.addSubview(buttonStackView)
-            
-            textStackView.addArrangedSubview(titleLabel)
-            textStackView.addArrangedSubview(descriptionLabel)
-            
-            buttonStackView.addArrangedSubview(dismissButton)
-            buttonStackView.addArrangedSubview(confirmButton)
+            containerView.addSubview(popupView)
         }
         
         func configureConstraints(for view: UIView) {
             containerView.snp.makeConstraints {
                 $0.edges.equalTo(view.safeAreaLayoutGuide)
             }
-            
-            mainPopupView.snp.makeConstraints {
-                $0.centerX.centerY.equalToSuperview()
+
+            popupView.snp.makeConstraints {
                 $0.leading.equalToSuperview().offset(.spacing16)
                 $0.trailing.equalToSuperview().inset(.spacing16)
+                $0.centerY.equalToSuperview()
                 $0.height.equalTo(Constant.popupHeight)
-            }
-            
-            textStackView.snp.makeConstraints {
-                $0.top.equalToSuperview().offset(Constant.topBottomMargin)
-                $0.centerX.equalToSuperview()
-            }
-            
-            buttonStackView.snp.makeConstraints {
-                $0.bottom.equalToSuperview().inset(Constant.topBottomMargin)
-                $0.centerX.equalToSuperview()
-            }
-            
-            titleLabel.snp.makeConstraints {
-                $0.height.equalTo(titleLabel.font.customLineHeight)
-            }
-            
-            descriptionLabel.snp.makeConstraints {
-                $0.height.equalTo(titleLabel.font.customLineHeight)
-            }
-            
-            dismissButton.snp.makeConstraints {
-                $0.width.equalTo(Constant.buttonWidth)
-                $0.height.equalTo(Constant.buttonHeight)
-            }
-            
-            confirmButton.snp.makeConstraints {
-                $0.width.equalTo(Constant.buttonWidth)
-                $0.height.equalTo(Constant.buttonHeight)
             }
         }
     }

--- a/Pyonsnal-Color/Pyonsnal-Color/Service/UserInfoService.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Service/UserInfoService.swift
@@ -27,6 +27,9 @@ final class UserInfoService {
     var adId: String {
         ASIdentifierManager.shared().advertisingIdentifier.uuidString
     }
+    var isMemberGuest: Bool? {
+        return memberInfo?.isGuest
+    }
     
     // MARK: - Initializer
     

--- a/Pyonsnal-Color/Pyonsnal-Color/Service/UserInfoService.swift
+++ b/Pyonsnal-Color/Pyonsnal-Color/Service/UserInfoService.swift
@@ -27,7 +27,7 @@ final class UserInfoService {
     var adId: String {
         ASIdentifierManager.shared().advertisingIdentifier.uuidString
     }
-    var isMemberGuest: Bool? {
+    var isGuest: Bool? {
         return memberInfo?.isGuest
     }
     


### PR DESCRIPTION
### 이슈
#166 

### 수정사항
로그인이 필요한 기능에 팝업 -> 로그인 화면 플로우를 추가했습니다.

로그인 필요 기능
  1. 찜하기 (ProductHome, EventHome, ProductSearch 리블렛)
  2. 리뷰 작성 & 좋아요/싫어요 (ProductDetail 리블렛)

### 스크린샷
|<img src=https://github.com/YAPP-Github/PyonsnalColor-iOS/assets/71054048/edc9d85e-34a7-4108-8c62-d6b3eef4dc8e width=300>|
|:-:|
