### PR TITLE
Info.plist에 앱 수출 규정 추가

### DIFF
--- a/Pyonsnal-Color/Pyonsnal-Color/Resource/Info.plist
+++ b/Pyonsnal-Color/Pyonsnal-Color/Resource/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>NSCameraUsageDescription</key>
 	<string>프로필 이미지를 찍기 위해 권한이 필요합니다.</string>
 	<key>NSUserTrackingUsageDescription</key>


### PR DESCRIPTION
### 이슈
# 172

### 수정사항
* Info.plist에 앱 수출 규정 정보 추가

### (기타, 스크린샷, 트러블슈팅) (선택 사항)
- 참고: https://developer.apple.com/documentation/security/complying_with_encryption_export_regulations